### PR TITLE
APS-2408 docs templates

### DIFF
--- a/documentation/concepts/!concept-template.md
+++ b/documentation/concepts/!concept-template.md
@@ -84,7 +84,7 @@ OR
 
 <!-- whatsnext -->
 
-## What's next? (optional)
+## Next steps (optional)
 
 If you would like to dive deeper or start implementing {concept}, check out the
 following resources:

--- a/documentation/concepts/!concept-template.md
+++ b/documentation/concepts/!concept-template.md
@@ -3,36 +3,40 @@ title: {Concept Name}
 ---
 <!-- template preamble -->
 
+## Template preamble (remove!)
+
 A concept page explains some aspect of the API Management Platform. They can be
-thought of as extended definitions of major abstractions, such as a resource or
-mechanism. Concept pages provide essential background, enabling readers to
+thought of as extended definitions of major abstractions, such as a resource (like Products) or
+mechanism (like an API Gateway). Concept pages provide essential background, enabling readers to
 understand the Platform, and thereby navigate tasks to achieve their goals.
 Typically, concept pages don't include sequences of steps, but instead provide
 links to tasks or tutorials.
 
 Considerations for page audience:
-- Chunking: Consider dividing the concept page into sections for different audiences.
-- Layer depths of explanation: Start with simple explanations for non-technical readers, then progress into detailed technical explanations.
-- Split: Consider splitting into multiple documents if audience needs vary greatly.
+
+- Layer depths of explanation: Start with simple, high-level explanations for non-technical readers, then progress into detailed technical explanations.
+- If that isn't enough, then consider dividing the concept page into sections for different audiences.
 
 To write a new concept page, copy this file. All text in {curly brackets} should be replaced or removed.
 
 For more information on concept pages, visit the [Good Docs Project](https://gitlab.com/tgdp/templates/-/tree/main/concept).
 
+---
+
 <!-- overview -->
 
-A summary paragraph introducing a concept, explaining its importance or
+{A summary paragraph introducing a concept, explaining its importance or
 relevance, and providing an overview of the content that will be covered
-in the document (scope).
+in the document (scope).}
 
-Typical wording to use is:
+{Typical wording to use is:}
 
 This article explains the basics of {concept} and how it works in {the tool or context}.
 
 {Then include a paragraph with a definition of the concept you are explaining.
 If more definitions are needed, include those definitions here as a bulleted list.}
 
-{Optional: Add visual aids to complement explanations (system diagram, flowchart, decision tree) - see [Good Docs](https://gitlab.com/tgdp/templates/-/blob/main/concept/process-concept.md#create-visual-aids-for-a-concept-document)}
+{Optional: Add visual aids to complement explanations (system diagram, flowchart, decision tree) - see the [Style Guide - Diagrams](/reference/style-guide.md#diagrams) and [Good Docs](https://gitlab.com/tgdp/templates/-/blob/main/concept/process-concept.md#create-visual-aids-for-a-concept-document).}
 
 (Optional) Image/Figure: {Image title, which concisely explains the image or
 figure.}
@@ -48,16 +52,29 @@ Typical wordings to use are:
 - The reason {X} is designed that way is because historically, ...
 - The idea of {X} originated from the growing demand for ...
 
-## Use cases (optional)
+## Use cases OR Purpose
 
-{Optional: Use this section to provide use cases and explain how a reader can
-benefit from a concept.}
+{Answer "How can I use it?" or "How does it help me?" from the reader's perspective.
+Use this section to explain the overall purpose and provide use
+cases to show how a reader can benefit from a concept.}
 
 ## Comparison of {thing being compared} (optional)
 
-{Use this section to compare options or alternatives.}
+{Use this section to compare options or alternatives within a concept.}
 
 Table: {Table title which concisely explains the comparison.}
+
+| Option   | Pros                                  | Cons                                  |
+|----------|---------------------------------------|---------------------------------------|
+| {Concept} option 1 | <ul><li>Pro 1 for Option 1</li><li>Pro 2 for Option 1</li></ul> | <ul><li>Con 1 for Option 1</li><li>Con 2 for Option 1</li></ul> |
+| {Concept} option 2 | <ul><li>Pro 1 for Option 2</li><li>Pro 2 for Option 2</li></ul> | <ul><li>Con 1 for Option 2</li><li>Con 2 for Option 2</li></ul> |
+
+OR
+
+| Use case   | Recommendation     | Why                       |
+|------------|--------------------|---------------------------|
+| Use case 1 | {Concept} option 1 | Reason for using option 1 |
+| Use case 2 | {Concept} option 2 | Reason for using option 2 |
 
 <!-- whatsnext -->
 
@@ -67,11 +84,14 @@ If you would like to dive deeper or start implementing {concept}, check out the
 following resources:
 
 How-to guides
+
 - [Natural next thing to do](/how-to/gwa-install.md)
 - [Something else to consider or explore](/how-to/private-route.md)
 
 Linked concepts
+
 - [Concept 1](/concepts/api-directory.md)
 
 External resources
+
 - [Kong](https://docs.konghq.com/gateway/latest/key-concepts/services/)

--- a/documentation/concepts/!concept-template.md
+++ b/documentation/concepts/!concept-template.md
@@ -6,18 +6,22 @@ title: {Concept Name}
 ## Template preamble (remove!)
 
 A concept page explains some aspect of the API Management Platform. They can be
-thought of as extended definitions of major abstractions, such as a resource (like Products) or
-mechanism (like an API Gateway). Concept pages provide essential background, enabling readers to
+thought of as extended definitions of major abstractions, such as a resource
+(like Products) or higher-level concept (like an API Gateway) or an overview of
+the Platform. Concept pages provide essential background, enabling readers to
 understand the Platform, and thereby navigate tasks to achieve their goals.
 Typically, concept pages don't include sequences of steps, but instead provide
 links to tasks or tutorials.
 
 Considerations for page audience:
 
-- Layer depths of explanation: Start with simple, high-level explanations for non-technical readers, then progress into detailed technical explanations.
-- If that isn't enough, then consider dividing the concept page into sections for different audiences.
+- Layer depths of explanation: Start with simple, high-level explanations for
+  non-technical readers, then progress into detailed technical explanations.
+- If that isn't enough, then consider dividing the concept page into sections
+  for different audiences.
 
-To write a new concept page, copy this file. All text in {curly brackets} should be replaced or removed.
+To write a new concept page, copy this file. All text in {curly brackets} should
+be replaced or removed.
 
 For more information on concept pages, visit the [Good Docs Project](https://gitlab.com/tgdp/templates/-/tree/main/concept).
 
@@ -36,7 +40,9 @@ This article explains the basics of {concept} and how it works in {the tool or c
 {Then include a paragraph with a definition of the concept you are explaining.
 If more definitions are needed, include those definitions here as a bulleted list.}
 
-{Optional: Add visual aids to complement explanations (system diagram, flowchart, decision tree) - see the [Style Guide - Diagrams](/reference/style-guide.md#diagrams) and [Good Docs](https://gitlab.com/tgdp/templates/-/blob/main/concept/process-concept.md#create-visual-aids-for-a-concept-document).}
+{Optional: Add visual aids to complement explanations (system diagram, flowchart, decision tree) -
+see the [Style Guide - Diagrams](/reference/style-guide.md#diagrams) and
+[Good Docs](https://gitlab.com/tgdp/templates/-/blob/main/concept/process-concept.md#create-visual-aids-for-a-concept-document).}
 
 (Optional) Image/Figure: {Image title, which concisely explains the image or
 figure.}

--- a/documentation/concepts/!concept-template.md
+++ b/documentation/concepts/!concept-template.md
@@ -1,0 +1,77 @@
+---
+title: {Concept Name}
+---
+<!-- template preamble -->
+
+A concept page explains some aspect of the API Management Platform. They can be
+thought of as extended definitions of major abstractions, such as a resource or
+mechanism. Concept pages provide essential background, enabling readers to
+understand the Platform, and thereby navigate tasks to achieve their goals.
+Typically, concept pages don't include sequences of steps, but instead provide
+links to tasks or tutorials.
+
+Considerations for page audience:
+- Chunking: Consider dividing the concept page into sections for different audiences.
+- Layer depths of explanation: Start with simple explanations for non-technical readers, then progress into detailed technical explanations.
+- Split: Consider splitting into multiple documents if audience needs vary greatly.
+
+To write a new concept page, copy this file. All text in {curly brackets} should be replaced or removed.
+
+For more information on concept pages, visit the [Good Docs Project](https://gitlab.com/tgdp/templates/-/tree/main/concept).
+
+<!-- overview -->
+
+A summary paragraph introducing a concept, explaining its importance or
+relevance, and providing an overview of the content that will be covered
+in the document (scope).
+
+Typical wording to use is:
+
+This article explains the basics of {concept} and how it works in {the tool or context}.
+
+{Then include a paragraph with a definition of the concept you are explaining.
+If more definitions are needed, include those definitions here as a bulleted list.}
+
+{Optional: Add visual aids to complement explanations (system diagram, flowchart, decision tree) - see [Good Docs](https://gitlab.com/tgdp/templates/-/blob/main/concept/process-concept.md#create-visual-aids-for-a-concept-document)}
+
+(Optional) Image/Figure: {Image title, which concisely explains the image or
+figure.}
+
+<!-- body -->
+
+## Background (optional)
+
+{Use this section to provide a reader with a context, prehistory, or background information.}
+
+Typical wordings to use are:
+
+- The reason {X} is designed that way is because historically, ...
+- The idea of {X} originated from the growing demand for ...
+
+## Use cases (optional)
+
+{Optional: Use this section to provide use cases and explain how a reader can
+benefit from a concept.}
+
+## Comparison of {thing being compared} (optional)
+
+{Use this section to compare options or alternatives.}
+
+Table: {Table title which concisely explains the comparison.}
+
+<!-- whatsnext -->
+
+## What's next? (optional)
+
+If you would like to dive deeper or start implementing {concept}, check out the
+following resources:
+
+How-to guides
+- [Natural next thing to do](/how-to/next.md)
+- [Something else to consider or explore](/how-to/more.md)
+
+Linked concepts
+- [Concept 1](/concepts/relevant.md)
+
+External resources
+- [Kong](https://docs.konghq.com/gateway/latest/key-concepts/services/)

--- a/documentation/concepts/!concept-template.md
+++ b/documentation/concepts/!concept-template.md
@@ -67,11 +67,11 @@ If you would like to dive deeper or start implementing {concept}, check out the
 following resources:
 
 How-to guides
-- [Natural next thing to do](/how-to/next.md)
-- [Something else to consider or explore](/how-to/more.md)
+- [Natural next thing to do](/how-to/gwa-install.md)
+- [Something else to consider or explore](/how-to/private-route.md)
 
 Linked concepts
-- [Concept 1](/concepts/relevant.md)
+- [Concept 1](/concepts/api-directory.md)
 
 External resources
 - [Kong](https://docs.konghq.com/gateway/latest/key-concepts/services/)

--- a/documentation/how-to/!how-to-template.md
+++ b/documentation/how-to/!how-to-template.md
@@ -106,3 +106,4 @@ Consider if the sub-task deserves it's own how-to page.}
 - [Related reference material](/reference/api.md)
 - [Something else to consider or explore](/how-to/more.md)
 - Read more about the [Relevant concept](/concepts/relevant.md)
+- 5 items max!

--- a/documentation/how-to/!how-to-template.md
+++ b/documentation/how-to/!how-to-template.md
@@ -51,6 +51,7 @@ Before you begin, ensure you:
   {Optional: Explanatory text}
 
   {Optional: Code sample or screenshot that helps your users complete this step.}
+  {Re screenshots: Only use an image when it would be significantly harder to explain with text alone. Otherwise, don't.}
 
   {Optional: The result of completing this step.}
 

--- a/documentation/how-to/!how-to-template.md
+++ b/documentation/how-to/!how-to-template.md
@@ -1,0 +1,98 @@
+---
+title: {Guide Title for a Specific Task}
+---
+<!-- template preamble -->
+
+A how-to page shows how to do a single thing, typically by giving a short
+sequence of steps. How-to pages have minimal explanation, but often provide links
+to conceptual topics that provide related background and knowledge.
+
+To write a new how-to page, copy this file. All text in {curly brackets} should be replaced or removed.
+
+For more information on how to fill in this template, read the [Good Docs Project guide](https://gitlab.com/tgdp/templates/-/blob/main/how-to/guide-how-to.md).
+
+<!-- overview -->
+
+This guide explains how to {insert a brief description of the task}.
+
+{Optional: Specify when and why your user might want to perform the task.}
+
+<!-- prerequisites -->
+
+## Before you begin
+
+{Optional: You should be familiar with how to do a [more basic task](/how-to/basic.md) or [concept](/concepts/topic.md).}
+
+Before you {insert a brief description of the task}, ensure you:
+
+- [Install gwa CLI](/how-to/gwa-install.md)
+- [Create a Namespace](/resources/gwa-commands.md#namespacecreate)
+- [Complete This](/how-to/do-this.md)
+- [Do That](/how-to/do-that.md)
+
+<!-- steps -->
+
+## {Sub-task name}
+
+{Optional: Provide a concise description of the purpose of this sub-task. Only include this if the purpose is not clear from the sub-task title.}
+
+{You can use this format to describe steps to complete a sub-task:}
+
+1. {Write the first step here. Use a verb to start.}
+
+  {Optional: Explanatory text}
+
+  {Optional: Code sample or screenshot that helps your users complete this step.}
+
+  {Optional: The result of completing this step.}
+
+1. {Write the second step here. Use a verb to start.}
+
+  {Substep 1 text}
+
+  {Substep 2 text}
+
+## {Second sub-task name}
+
+{Repeat as above}
+
+{Optional: Use tabs for documenting multiple user paths to achieve the same end, for example, using the CLI or Portal UI.}
+
+=== "CLI"
+    1. Create a Product configuration using the YAML template.
+    1. Publish the Product - `gwa apply -i <product.yaml>`
+=== "Web UI"
+    1. Navigate to **Namespaces** -> **Products**.
+    1. Click **New Product** in the top right.
+
+### {Sub-sub-task}
+
+{This section is optional. Only include h3 headings if the sub-task is big and complex and demands splitting.
+Consider if the sub-task deserves it's own how-to page.}
+
+{Optional: Use example code blocks as needed}
+
+{**TO DISCUSS**: When to use placeholders in example code}
+
+```yaml
+services:
+  - name: my-service
+    host: httpbin.org
+    tags: [ns.<NAMESPACE>]
+    port: 443
+    protocol: https
+    retries: 0
+    routes:
+      - name: my-service-route
+        tags: [ns.<NAMESPACE>]
+        hosts:
+          - <MYSERVICE>.cluster.local
+```
+
+<!-- whatsnext -->
+
+## What's next?
+
+- [Natural next thing to do](/how-to/next.md)
+- [Something else to consider or explore](/how-to/more.md)
+- Read more about the [Relevant concept](/concepts/relevant.md)

--- a/documentation/how-to/!how-to-template.md
+++ b/documentation/how-to/!how-to-template.md
@@ -131,7 +131,7 @@ Consider if the sub-task deserves it's own how-to page.}
 
 <!-- whatsnext -->
 
-## What's next?
+## Next steps
 
 - [Natural next thing to do](/how-to/gwa-install.md)
 - [Related reference material](/reference/glossary.md)

--- a/documentation/how-to/!how-to-template.md
+++ b/documentation/how-to/!how-to-template.md
@@ -7,6 +7,8 @@ A how-to page shows how to do a single thing, typically by giving a short
 sequence of steps. How-to pages have minimal explanation, but often provide links
 to conceptual topics that provide related background and knowledge.
 
+How-tos should provide the available environments (`test`/`prod`) and endpoints, when applicable.
+
 To write a new how-to page, copy this file. All text in {curly brackets} should be replaced or removed.
 
 For more information on how-to pages, read the [Good Docs Project guide](https://gitlab.com/tgdp/templates/-/blob/main/how-to/guide-how-to.md).
@@ -23,14 +25,14 @@ This guide explains how to {insert a brief description of the task}.
 
 ## Before you begin
 
-{Optional: You should be familiar with how to do a [more basic task](/how-to/basic.md) or [concept](/concepts/topic.md).}
+{Optional: You should be familiar with how to do a [more basic task](/how-to/gwa-install.md) or [concept](/concepts/api-directory.md).}
 
 Before you begin, ensure you:
 
 - [Install gwa CLI](/how-to/gwa-install.md)
 - [Create a Namespace](/resources/gwa-commands.md#namespacecreate)
-- [Complete This](/how-to/do-this.md)
-- [Do That](/how-to/do-that.md)
+- [Complete This](/how-to/create-gateway-service.md)
+- [Do That](/how-to/generate-service-account.md)
 
 <!-- steps -->
 
@@ -74,24 +76,48 @@ Before you begin, ensure you:
 !!! warning "Don't forget"
     Use callouts to communicate **important** information.
 
-{Optional: Use example code blocks as needed}
+{Optional: Use example code blocks as needed.}
 
-{**TO DISCUSS**: When to use placeholders in example code}
+{**TO DISCUSS**: When/how to use `<PLACEHOLDERS>` in example code, in particular in YAML configs}
+
+1. Which elements to use placeholders for? Strike a balance:
+  - Use placeholders for elements that users absolutely need to customize for their specific use case or the example will not work.
+    - Let's develop some standards on which elements this would include
+    - `<NAMESPACE>`
+    - `<CLIENT_ID>` and `<CLIENT_SECRET>`
+    - ?
+  - Use example values (without placeholders) for non-essential configuration
+    - How to distinguish these values from the required (non-user chosen) values for a given config?
+    - Explain these are example values in comments/accompanying text if there may be any doubt
+    - Again, what elements would this include?
+    - e.g. in a Service, `host: httpbin.org`
+
+2. How to annotate code blocks?
+   - Option A: Use comments inside the code block
+   - Option B: Use accompanying descriptive text following the code block (preferred)
+
+3. Conventions for service and route names
+   - 
 
 ```yaml
 services:
   - name: my-service
     host: httpbin.org
+    # Replace <NAMESPACE> with the namespace specific to your environment.
     tags: [ns.<NAMESPACE>]
-    port: 443
-    protocol: https
-    retries: 0
     routes:
       - name: my-service-route
+        # Tags should include a namespace identifier, replace <NAMESPACE>.
         tags: [ns.<NAMESPACE>]
+        # Replace <MYSERVICE> with your service's desired internal name.
         hosts:
           - <MYSERVICE>.cluster.local
 ```
+
+{Replace the following / Where,}:
+
+- `<NAMESPACE>`: Replace with your API Service's Portal Namespace where the service resides, e.g. `gw-e8a5a`.
+- `<MYSERVICE>`: Replace this with the name of the service as you would like it to be known within the local network, for example, `api-service`.
 
 ### {Sub-task details}
 
@@ -102,8 +128,8 @@ Consider if the sub-task deserves it's own how-to page.}
 
 ## What's next?
 
-- [Natural next thing to do](/how-to/next.md)
-- [Related reference material](/reference/api.md)
-- [Something else to consider or explore](/how-to/more.md)
-- Read more about the [Relevant concept](/concepts/relevant.md)
+- [Natural next thing to do](/how-to/gwa-install.md)
+- [Related reference material](/reference/glossary.md)
+- [Something else to consider or explore](/how-to/private-route.md)
+- Read more about the [Relevant concept](/concepts/api-directory.md)
 - 5 items max!

--- a/documentation/how-to/!how-to-template.md
+++ b/documentation/how-to/!how-to-template.md
@@ -3,6 +3,8 @@ title: {Guide Title for a Specific Task}
 ---
 <!-- template preamble -->
 
+## Template preamble (remove!)
+
 A how-to page shows how to do a single thing, typically by giving a short
 sequence of steps. How-to pages have minimal explanation, but often provide links
 to conceptual topics that provide related background and knowledge.
@@ -12,6 +14,8 @@ How-tos should provide the available environments (`test`/`prod`) and endpoints,
 To write a new how-to page, copy this file. All text in {curly brackets} should be replaced or removed.
 
 For more information on how-to pages, read the [Good Docs Project guide](https://gitlab.com/tgdp/templates/-/blob/main/how-to/guide-how-to.md).
+
+---
 
 <!-- overview -->
 
@@ -110,7 +114,7 @@ services:
         # Tags should include a namespace identifier, replace <NAMESPACE>.
         tags: [ns.<NAMESPACE>]
         # Replace <MYSERVICE> with your service's desired internal name.
-        hosts:
+        hosts: 
           - <MYSERVICE>.cluster.local
 ```
 

--- a/documentation/how-to/api-discovery.md
+++ b/documentation/how-to/api-discovery.md
@@ -139,7 +139,7 @@ Now it's time to publish the Dataset:
 ## Link Your Dataset to a Product
 
 If you've already worked through the [Quick Start
-tutorial](/tutorial/quick-start.md) or set up a Gateway Service, you may already
+tutorial](/tutorials/quick-start.md) or set up a Gateway Service, you may already
 have a Product. In this case, we can associate the Product with a Dataset:
 
 1. Open the [Products](https://api.gov.bc.ca/manager/products) page in the API Services Portal.

--- a/documentation/how-to/create-gateway-service.md
+++ b/documentation/how-to/create-gateway-service.md
@@ -66,7 +66,7 @@ security: []
 paths:
   /headers:
     get:
-      operationId: get-heaers
+      operationId: get-headers
       summary: Returns the request headers.
       responses:
         "4XX":

--- a/documentation/how-to/create-gateway-service.md
+++ b/documentation/how-to/create-gateway-service.md
@@ -123,7 +123,7 @@ deck file openapi2kong -s openapi.yaml -o gw.yaml --select-tag ns.<GW-NAMESPACE>
 gwa publish-gateway gw.yaml
 ```
 
-## What's next?
+## Next steps
 
 - [Add Client Credential Protection](/how-to/client-cred-flow.md)
 - [Configure a Private Route](/how-to/private-route.md)

--- a/documentation/reference/!plugin-template.md
+++ b/documentation/reference/!plugin-template.md
@@ -1,0 +1,79 @@
+---
+title: {Plugin Name}
+---
+<!-- template preamble -->
+
+## Template preamble (remove!)
+
+Reference articles concisely present information as a structured set of entries,
+with little to no procedural or instructional content. They are like the
+nutritional information on a food package.
+
+Alongside other one-off reference page types, we will have a collection of Kong
+plugin reference pages.
+
+To write a new plugin reference page, copy this file. All text in {curly brackets} should be replaced or removed.
+
+---
+
+<!-- overview -->
+
+{A sentence or two introducing the plugin and its core functionality.
+Draw from the [Kong Hub](https://docs.konghq.com/hub/) plugin pages' Overview section.}
+
+The {plugin name} plugin lets you {what the plugin is used for}.
+
+<!-- config-reference -->
+
+## Configuration reference
+
+{No need to duplicate the docs from Kong for stock plugins!}
+
+This is a stock plugin from Kong Hub. See the [configuration reference
+page](https://docs.konghq.com/hub/kong-inc/{plugin-name}/{kong-version}/configuration/) for a list of parameters and protocol compatibility notes.
+
+{For custom plugins, we should list the parameters}
+
+This is a custom plugin managed by the API Program Services team. 
+
+Here is a list of all the parameters which can be used in this plugin's `config` section:
+
+- **parameter**
+  
+  {datatype} | {required} | {default: `default_value`} | {additional constraints, e.g. between, len_min} | {Must be one of: `option1`, `option2`}
+  
+  Description: {A sentence or two describing the field. If applicable, describe value options.}
+
+<!-- examples -->
+
+## Common usage example
+
+The {plugin name} plugin can be used in order to {specific desired outcome}.
+
+To {short description of desired outcome}, add this section to your GatewayService YAML configuration file:
+
+```yaml
+plugins:
+- name: rate-limiting
+  service: <SERVICE_NAME>
+  config:
+    second: 5
+    hour: 10000
+    policy: local
+```
+
+Replace <SERVICE_NAME> with the name of the service that this plugin configuration will target.
+
+### {Optional: Another use case}
+
+The {plugin name} plugin can be used in order to {specific desired outcome}.
+
+{...}
+
+
+## {Special consideration}
+
+{Optional: Some plugins have special considerations which we may want to
+highlight and give guidance around different use cases}
+
+{For example, for the Rate Limiting plugin, the [Strategies](https://docs.konghq.com/hub/kong-inc/rate-limiting/#strategies) should be mentioned.}

--- a/documentation/reference/!plugin-template.md
+++ b/documentation/reference/!plugin-template.md
@@ -12,7 +12,8 @@ nutritional information on a food package.
 Alongside other one-off reference page types, we will have a collection of Kong
 plugin reference pages.
 
-To write a new plugin reference page, copy this file. All text in {curly brackets} should be replaced or removed.
+To write a new plugin reference page, copy this file. All text in {curly
+brackets} should be replaced or removed.
 
 ---
 
@@ -30,11 +31,12 @@ The {plugin name} plugin lets you {what the plugin is used for}.
 {No need to duplicate the docs from Kong for stock plugins!}
 
 This is a stock plugin from Kong Hub. See the [configuration reference
-page](https://docs.konghq.com/hub/kong-inc/{plugin-name}/{kong-version}/configuration/) for a list of parameters and protocol compatibility notes.
+page](https://docs.konghq.com/hub/kong-inc/{plugin-name}/{kong-version}/configuration/)
+for a list of parameters and protocol compatibility notes.
 
 {For custom plugins, we should list the parameters}
 
-This is a custom plugin managed by the API Program Services team. 
+This is a custom plugin managed by the API Program Services team.
 
 Here is a list of all the parameters which can be used in this plugin's `config` section:
 
@@ -50,7 +52,8 @@ Here is a list of all the parameters which can be used in this plugin's `config`
 
 The {plugin name} plugin can be used in order to {specific desired outcome}.
 
-To {short description of desired outcome}, add this section to your GatewayService YAML configuration file:
+To {short description of desired outcome}, add this section to your
+GatewayService YAML configuration file:
 
 ```yaml
 plugins:
@@ -62,7 +65,8 @@ plugins:
     policy: local
 ```
 
-Replace <SERVICE_NAME> with the name of the service that this plugin configuration will target.
+Replace <SERVICE_NAME> with the name of the service that this plugin
+configuration will target.
 
 ### {Optional: Another use case}
 
@@ -70,10 +74,9 @@ The {plugin name} plugin can be used in order to {specific desired outcome}.
 
 {...}
 
-
 ## {Special consideration}
 
 {Optional: Some plugins have special considerations which we may want to
-highlight and give guidance around different use cases}
+highlight and give guidance around different use cases.}
 
 {For example, for the Rate Limiting plugin, the [Strategies](https://docs.konghq.com/hub/kong-inc/rate-limiting/#strategies) should be mentioned.}

--- a/documentation/reference/releases/2021-jun.md
+++ b/documentation/reference/releases/2021-jun.md
@@ -21,4 +21,4 @@ If you have questions or require assistance, please visit our [RocketChat Channe
 
 ## Links
 
-- [API Owner User Journey](/guides/owner-journey.md)
+- [API Owner User Journey](/guides/owner-journey-v1.md)

--- a/documentation/reference/releases/2023-jan-1.2.6.md
+++ b/documentation/reference/releases/2023-jan-1.2.6.md
@@ -13,7 +13,7 @@ The API Services Portal has been updated with new features, enhancements, and bu
 - **Shared IdP**:
   - This feature allows API Providers to leverage the SSO Gold-tier Keycloak cluster to manage Client Credentials without having to deal directly with the cluster. The APS team has a custom realm on this Keycloak cluster called apigw, which is administered by the API Services Portal. To use it, [follow these steps](/how-to/client-cred-flow.md/#2-grant-access-to-the-identity-provider).
 - **Private Routing**:
-  - This feature allows API Providers to make private API endpoints, which can have security benefits. [Learn more here](/guides/owner-journey.md#private-routing).
+  - This feature allows API Providers to make private API endpoints, which can have security benefits. [Learn more here](/how-to/private-route.md).
 - **New Plugins**
   - [Waiting Queue](/gateway/plugins/waiting-queue.md#waiting-queue): Support Waiting Queue solutions, such as [https://github.com/bcgov/WaitingQueue](https://github.com/bcgov/WaitingQueue).
   - [Kong Upstream Auth Basic](/gateway/plugins/kong-upstream-auth-basic.md#kong-upstream-auth-basic): Kong Plugin to add HTTP Basic Authentication to the upstream request header.

--- a/documentation/reference/style-guide.md
+++ b/documentation/reference/style-guide.md
@@ -340,6 +340,32 @@ Use root-relative links to support documents moving around without breaking link
 - Use the number one (`1.`) for all items in ordered lists.
 - Use (`+`), (`*`), or (`-`) for unordered lists.
 
+### Diagrams
+
+Use Mermaid to create diagrams by tagging a code block with the `mermaid` language tag. See the [Kubernetes Diagram Guide](https://kubernetes.io/docs/contribute/style/diagram-guide/) more information on creating diagrams with Mermaid (and don't forget about GenAI).
+
+!!! Note
+	Mermaid diagrams won't show when using the [devhub-techdocs-publish](https://github.com/bcgov/devhub-techdocs-publish/blob/main/docs/index.md#how-to-use-the-docker-image-to-preview-content-locally) to preview the documentation locally. 
+    They will show up when published to DevHub's preview or production sites.
+
+````
+```mermaid
+  graph TD;
+      A-->B;
+      A-->C;
+      B-->D;
+      C-->D;
+```
+````
+
+```mermaid
+  graph TD;
+      A-->B;
+      A-->C;
+      B-->D;
+      C-->D;
+```
+
 ## Content best practices
 
 This section contains suggested best practices for clear, concise, and consistent

--- a/documentation/reference/style-guide.md
+++ b/documentation/reference/style-guide.md
@@ -317,7 +317,7 @@ Use root-relative links to support documents moving around without breaking link
 
 | Do | Don't |
 | -- | ----- |
-| `[Tutorial](/tutorial/quick-start.md)` (even if linking from another page in `/tutorial`) | `[Tutorial](quick-start.md)` or `[Tutorial](../quick-start.md)` |
+| `[Tutorial](/tutorials/quick-start.md)` (even if linking from another page in `/tutorials`) | `[Tutorial](quick-start.md)` or `[Tutorial](../quick-start.md)` |
 
 ### Lists
 

--- a/documentation/reference/style-guide.md
+++ b/documentation/reference/style-guide.md
@@ -172,7 +172,7 @@ Use meaningful variable names for the context.
 | Do | Don't |
 | -- | ----- |
 | `gwa apply --input <gateway-config.yaml>` | `gwa apply --input [file]` |
-| `tags: [ <namespace> ]` | `tags: [ _NS_ ]` |
+| `tags: [ ns.<namespace> ]` | `tags: [ _NS_ ]` |
 | `gwa get <resource>` | `gwa get <foo>` |
 | `curl https://<MYSERVICE>.api.gov.bc.ca/headers` | `curl https://*MYSERVICE*.api.gov.bc.ca/headers` |
 

--- a/documentation/tutorials/!tutorial-template.md
+++ b/documentation/tutorials/!tutorial-template.md
@@ -1,5 +1,5 @@
 ---
-title: {Tutorial Title for a Specific Task}
+title: {Tutorial Title}
 ---
 <!-- template preamble -->
 
@@ -110,3 +110,4 @@ In this tutorial, you learned how to:
 - [Natural next thing to do](/how-to/next.md)
 - [Something else to consider or explore](/how-to/more.md)
 - Read more about the [Relevant concept](/concepts/relevant.md)
+- 5 items max!

--- a/documentation/tutorials/!tutorial-template.md
+++ b/documentation/tutorials/!tutorial-template.md
@@ -129,7 +129,7 @@ In this tutorial, you learned how to:
 
 <!-- whatsnext -->
 
-## What's next?
+## Next steps
 
 - [Natural next thing to do](/how-to/gwa-install.md)
 - [Something else to consider or explore](/how-to/private-route.md)

--- a/documentation/tutorials/!tutorial-template.md
+++ b/documentation/tutorials/!tutorial-template.md
@@ -90,6 +90,27 @@ services:
           - <MYSERVICE>.cluster.local
 ```
 
+<!-- cleanup -->
+
+## Clean up
+
+{Optional: Provide instructions on how to clean up the resources resulting from the tutorial.}
+
+{1. On the **Consumers** page, delete any Consumers which were granted access to the service.}
+
+!!! danger
+    This following action is irreversible. Ensure the correct Namespace is active first with:
+    ``` linenums="0"
+    gwa namespace current
+    ```
+
+1. Delete the Namespace and associated services which were set up using during tutorial with this command:
+
+  ``` linenums="0"
+  gwa namespace destroy --force
+  ```
+
+
 <!-- summary -->
 
 ## Summary

--- a/documentation/tutorials/!tutorial-template.md
+++ b/documentation/tutorials/!tutorial-template.md
@@ -3,6 +3,8 @@ title: {Tutorial Title}
 ---
 <!-- template preamble -->
 
+## Template preamble (remove!)
+
 Tutorials are learning-oriented and targeted at beginners or experts to help
 them learn a skill through hands-on experience. A tutorial page shows how to
 accomplish a goal that is larger than a single task, following a single, carefully
@@ -15,6 +17,8 @@ Tutorials should use the test environment (when applicable).
 To write a new tutorial page, copy this file. All text in {curly brackets} should be replaced or removed.
 
 For more information on tutorial pages, read the [Good Docs Project guide](https://gitlab.com/tgdp/templates/-/blob/main/tutorial/guide-tutorial.md).
+
+---
 
 <!-- overview -->
 

--- a/documentation/tutorials/!tutorial-template.md
+++ b/documentation/tutorials/!tutorial-template.md
@@ -1,21 +1,35 @@
 ---
-title: {Guide Title for a Specific Task}
+title: {Tutorial Title for a Specific Task}
 ---
 <!-- template preamble -->
 
-A how-to page shows how to do a single thing, typically by giving a short
-sequence of steps. How-to pages have minimal explanation, but often provide links
-to conceptual topics that provide related background and knowledge.
+Tutorials are learning-oriented and targeted at beginners or experts to help
+them learn a skill through hands-on experience. A tutorial page shows how to
+accomplish a goal that is larger than a single task, following a carefully
+managed path from start to finish. Tutorials should assume users have limited
+prior experience and thus include surface-level explanations of core concepts, while
+linking to related concept pages for deeper explanations.
 
-To write a new how-to page, copy this file. All text in {curly brackets} should be replaced or removed.
+To write a new tutorial page, copy this file. All text in {curly brackets} should be replaced or removed.
 
-For more information on how-to pages, read the [Good Docs Project guide](https://gitlab.com/tgdp/templates/-/blob/main/how-to/guide-how-to.md).
+For more information on tutorial pages, read the [Good Docs Project guide](https://gitlab.com/tgdp/templates/-/blob/main/tutorial/guide-tutorial.md).
 
 <!-- overview -->
 
-This guide explains how to {insert a brief description of the task}.
+In this tutorial, you'll learn how to {insert brief description of the main tutorial task}. This tutorial is intended for {audience}.
 
-{Optional: Specify when and why your user might want to perform the task.}
+By the end of this tutorial, you'll be able to:
+
+- Learning objective 1
+- Learning objective 2
+- Learning objective 3
+
+<!-- background -->
+
+{This section is optional. Feel free to use some of the text below to help you get started.}
+
+- {product} is a {product type} that you can use to {common use case}...
+- Using {feature} enables you to {pain point}...
 
 {Optional: Include links/tooltips to relevant concepts when terms are introduced here or in the `steps` section.}
 
@@ -58,22 +72,6 @@ Before you begin, ensure you:
 
 {Repeat as above}
 
-{Note on multiple paths: Making users choose between multiple ways of doing this
- is confusing. When it comes to CLI vs UI, the CLI is generally the recommended
- path, so *only* include CLI instructions.}
-
-{Optional: Use tabs for documenting multiple user paths to achieve the same end, for example, using the CLI or Portal UI.}
-
-=== "CLI"
-    1. Create a Product configuration using the YAML template.
-    2. Publish the Product - `gwa apply -i <product.yaml>`
-=== "Web UI"
-    1. Navigate to **Namespaces** -> **Products**.
-    2. Click **New Product** in the top right.
-
-!!! warning "Don't forget"
-    Use callouts to communicate **important** information.
-
 {Optional: Use example code blocks as needed}
 
 {**TO DISCUSS**: When to use placeholders in example code}
@@ -93,16 +91,22 @@ services:
           - <MYSERVICE>.cluster.local
 ```
 
-### {Sub-task details}
+<!-- summary -->
 
-{This section is optional. Only include h3 headings if the sub-task is big and complex and demands splitting.
-Consider if the sub-task deserves it's own how-to page.}
+## Summary
+
+{Use this section to summarize what the user learned in the tutorial.}
+
+In this tutorial, you learned how to:
+
+- Summary point 1
+- Summary point 2
+- Summary point 3
 
 <!-- whatsnext -->
 
 ## What's next?
 
 - [Natural next thing to do](/how-to/next.md)
-- [Related reference material](/reference/api.md)
 - [Something else to consider or explore](/how-to/more.md)
 - Read more about the [Relevant concept](/concepts/relevant.md)

--- a/documentation/tutorials/!tutorial-template.md
+++ b/documentation/tutorials/!tutorial-template.md
@@ -5,10 +5,12 @@ title: {Tutorial Title}
 
 Tutorials are learning-oriented and targeted at beginners or experts to help
 them learn a skill through hands-on experience. A tutorial page shows how to
-accomplish a goal that is larger than a single task, following a carefully
+accomplish a goal that is larger than a single task, following a single, carefully
 managed path from start to finish. Tutorials should assume users have limited
 prior experience and thus include surface-level explanations of core concepts, while
 linking to related concept pages for deeper explanations.
+
+Tutorials should use the test environment (when applicable).
 
 To write a new tutorial page, copy this file. All text in {curly brackets} should be replaced or removed.
 
@@ -37,14 +39,14 @@ By the end of this tutorial, you'll be able to:
 
 ## Before you begin
 
-{Optional: You should be familiar with how to do a [more basic task](/how-to/basic.md) or [concept](/concepts/topic.md).}
+{Intro tutorials should have no prerequisites, though more advanced tutorials might have some.}
+
+{Optional: You should be familiar with how to do a [more basic task](/how-to/gwa-install.md) or [concept](/concepts/api-directory.md).}
 
 Before you begin, ensure you:
 
 - [Install gwa CLI](/how-to/gwa-install.md)
 - [Create a Namespace](/resources/gwa-commands.md#namespacecreate)
-- [Complete This](/how-to/do-this.md)
-- [Do That](/how-to/do-that.md)
 
 <!-- steps -->
 
@@ -74,16 +76,13 @@ Before you begin, ensure you:
 
 {Optional: Use example code blocks as needed}
 
-{**TO DISCUSS**: When to use placeholders in example code}
+{**TO DISCUSS**: When to use placeholders in example code - see [how-to template](/how-to/!how-to-template.md)}
 
 ```yaml
 services:
   - name: my-service
     host: httpbin.org
     tags: [ns.<NAMESPACE>]
-    port: 443
-    protocol: https
-    retries: 0
     routes:
       - name: my-service-route
         tags: [ns.<NAMESPACE>]
@@ -107,7 +106,7 @@ In this tutorial, you learned how to:
 
 ## What's next?
 
-- [Natural next thing to do](/how-to/next.md)
-- [Something else to consider or explore](/how-to/more.md)
-- Read more about the [Relevant concept](/concepts/relevant.md)
+- [Natural next thing to do](/how-to/gwa-install.md)
+- [Something else to consider or explore](/how-to/private-route.md)
+- Read more about the [Relevant concept](/concepts/api-directory.md)
 - 5 items max!


### PR DESCRIPTION
Deployed to dev.developer when I opened the PR. Docs aren't shown in directory but available at their paths, e.g. https://dev.developer.gov.bc.ca/docs/default/component/aps-infra-platform-docs/how-to/!how-to-template