### PR TITLE
Show definition tooltips for glossary terms in docs

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -53,7 +53,7 @@ jobs:
         continue-on-error: true
 
       - name: Print directory structure
-        run: ls -R /github/workspace
+        run: ls -R
 
   publish-techdocs-site:
     runs-on: ubuntu-latest
@@ -66,7 +66,7 @@ jobs:
           path: substituted_content
 
       - name: Print directory structure
-        run: ls -R /github/workspace
+        run: ls -R
 
       - name: Build TechDocs
         uses: bcgov/devhub-techdocs-publish@stable  

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -42,7 +42,7 @@ jobs:
         id: build_and_publish
         with:
           publish: 'true'
-          production: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }} 
+          production: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy_location == 'prod' }}
           bucket_name: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
           s3_access_key_id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -52,6 +52,9 @@ jobs:
           cp catalog-info.yaml substituted_content
         continue-on-error: true
 
+      - name: Print directory structure
+        run: ls -R /github/workspace
+
   publish-techdocs-site:
     runs-on: ubuntu-latest
     name: Build and publish techdocs
@@ -61,6 +64,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: substituted_content
+
+      - name: Print directory structure
+        run: ls -R /github/workspace
 
       - name: Build TechDocs
         uses: bcgov/devhub-techdocs-publish@stable  

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -2,7 +2,7 @@ name: Publish TechDocs
 
 on:
   push:
-    branches: [ test, main, APS-2409-sub-glossary ]
+    branches: [ test, main ]
     paths:
       - "documentation/**"
       - "mkdocs.yml"

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -7,6 +7,7 @@ on:
       - "documentation/**"
       - "mkdocs.yml"
       - "catalog-info.yaml"
+      - "scripts/**"
   workflow_dispatch:
     inputs:
       deploy_location:

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -1,7 +1,7 @@
 name: Publish TechDocs
 on:
   push:
-    branches: [test, main]
+    branches: [test, main, APS-2409-sub-glossary]
     paths:
       - "documentation/**"
       - "mkdocs.yml"
@@ -18,10 +18,26 @@ on:
           - prod
 
 jobs:
+  substitute-glossary:
+    runs-on: ubuntu-latest
+    name: Substitute glossary terms etc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+          architecture: "x64"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yaml
+      - name: Run python Script
+        run: python scripts/sub_glossary.py
   publish-techdocs-site:
     runs-on: ubuntu-latest
-
-    name: A job to build and publish techdocs content
+    name: Build and publish techdocs
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -21,26 +21,46 @@ jobs:
   substitute-glossary:
     runs-on: ubuntu-latest
     name: Substitute glossary terms etc
+    outputs:
+      substituted_folder: ${{ steps.save_content.outputs.substituted_folder }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
           architecture: "x64"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pyyaml
+
       - name: Run python Script
+        id: sub_glossary
         run: python scripts/sub_glossary.py
+        
+      - name: Save substituted content
+        id: save_content
+        run: |
+          mkdir -p substituted_content/docs
+          cp -r documentation substituted_content/docs
+          sed -i 's/docs_dir: documentation/docs_dir: docs/' mkdocs.yml
+          cp mkdocs.yml substituted_content
+          cp catalog-info.yaml substituted_content
+        continue-on-error: true
+
   publish-techdocs-site:
     runs-on: ubuntu-latest
     name: Build and publish techdocs
+    needs: substitute-glossary
     steps:
-      - name: Checkout
+      - name: Checkout substituted content
         uses: actions/checkout@v4
+        with:
+          path: substituted_content
 
       - name: Build TechDocs
         uses: bcgov/devhub-techdocs-publish@stable  

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install yaml
+          pip install pyyaml
       - name: Run python Script
         run: python scripts/sub_glossary.py
   publish-techdocs-site:

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -7,7 +7,7 @@ on:
       - "documentation/**"
       - "mkdocs.yml"
       - "catalog-info.yaml"
-      - "scripts/**"
+      - "scripts/**"  
   workflow_dispatch:
     inputs:
       deploy_location:
@@ -26,23 +26,43 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Determine deployment environment
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" || "${{ github.event.inputs.deploy_location }}" == "prod" ]]; then
+            echo "DEPLOY_ENV=prod" >> $GITHUB_ENV
+          else
+            echo "DEPLOY_ENV=dev" >> $GITHUB_ENV
+          fi
+
+      - name: Set base URL
+        run: |
+          if [[ "${{ env.DEPLOY_ENV }}" == "prod" ]]; then
+            echo "DOCS_URL=https://developer.gov.bc.ca/docs/default/component/aps-infra-platform-docs" >> $GITHUB_ENV
+          else
+            echo "DOCS_URL=https://dev.developer.gov.bc.ca/docs/default/component/aps-infra-platform-docs" >> $GITHUB_ENV
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
           architecture: "x64"
+      
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pyyaml
+      
       - name: Run python Script
         run: python scripts/sub_glossary.py
+
       - name: Build TechDocs
         uses: bcgov/devhub-techdocs-publish@stable
         id: build_and_publish
         with:
           publish: 'true'
-          production: ${{ github.ref == 'refs/heads/main' || github.event.inputs.deploy_location == 'prod' }}
+          production: ${{ env.DEPLOY_ENV == 'prod' && 'true' || 'false' }}
           bucket_name: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
           s3_access_key_id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -1,7 +1,8 @@
 name: Publish TechDocs
+
 on:
   push:
-    branches: [test, main, APS-2409-sub-glossary]
+    branches: [ test, main, APS-2409-sub-glossary ]
     paths:
       - "documentation/**"
       - "mkdocs.yml"
@@ -18,62 +19,29 @@ on:
           - prod
 
 jobs:
-  substitute-glossary:
+  publish-techdocs-site:
     runs-on: ubuntu-latest
-    name: Substitute glossary terms etc
-    outputs:
-      substituted_folder: ${{ steps.save_content.outputs.substituted_folder }}
+    name: Build and publish techdocs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
           architecture: "x64"
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install pyyaml
-
       - name: Run python Script
-        id: sub_glossary
         run: python scripts/sub_glossary.py
-        
-      - name: Save substituted content
-        id: save_content
-        run: |
-          mkdir -p substituted_content/docs
-          cp -r documentation substituted_content/docs
-          sed -i 's/docs_dir: documentation/docs_dir: docs/' mkdocs.yml
-          cp mkdocs.yml substituted_content
-          cp catalog-info.yaml substituted_content
-        continue-on-error: true
-
-      - name: Print directory structure
-        run: ls -R
-
-  publish-techdocs-site:
-    runs-on: ubuntu-latest
-    name: Build and publish techdocs
-    needs: substitute-glossary
-    steps:
-      - name: Checkout substituted content
-        uses: actions/checkout@v4
-        with:
-          path: substituted_content
-
-      - name: Print directory structure
-        run: ls -R
-
       - name: Build TechDocs
-        uses: bcgov/devhub-techdocs-publish@stable  
+        uses: bcgov/devhub-techdocs-publish@stable
         id: build_and_publish
         with:
           publish: 'true'
-          production:  ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }} 
+          production: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }} 
           bucket_name: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
           s3_access_key_id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ docker pull ghcr.io/bcgov/devhub-techdocs-publish
 docker run -it -p 3000:3000 -v $(pwd):/github/workspace ghcr.io/bcgov/devhub-techdocs-publish preview
 ```
 
-## Validate Broken Links
+## Validate broken links
 
 First run the local preview. Then:
 
@@ -31,3 +31,15 @@ cd gwa-cli
 just docs
 cp docs/gwa-commands.md ../../documentation/resources/gwa-commands.md
 ```
+
+## Insert glossary term references
+
+Use this tag when introducing key concepts. Most often this will be in an introductory / overview section.
+
+`{{ glossary_tooltip term_id="api-services-portal" text="API Services Portal" }}`
+
+`term_id`: The term to reference, defined in `scripts/glossary_reference.yaml`.
+
+`text` (optional): The displayed text. If not provided, the `name` (in Title Case) is used.
+
+The result is the display text specially styled with a tooltip including the definition and a link to a relevant reference URL (if defined in `glossary_reference.yaml`).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Use this tag when introducing key concepts. Most often this will be in an introd
 
 `{{ glossary_tooltip term_id="api-services-portal" text="API Services Portal" }}`
 
-`term_id`: The term to reference, defined in `scripts/glossary_reference.yaml`.
+`term_id`: The term to reference, defined in `scripts/glossary_reference.yaml`. Must be passed first as first attribute.
 
 `text` (optional): The displayed text. If not provided, the `name` (in Title Case) is used.
 

--- a/documentation/tutorials/quick-start.md
+++ b/documentation/tutorials/quick-start.md
@@ -12,7 +12,7 @@ publishDate: "2021-06-10T20:00:00.000-08:00"
 > NOTE: As of Sep 19, 2023, we have upgraded our command line interface to version 2, which is used in this tutorial. 
 > For a tutorial using v1 of the `gwa` CLI visit [API Provider User Journey v1](/guides/owner-journey-v1.md).
 
-The following steps guide an API Provider through setting up an API on the BC Government API Gateway in a Test/Training instance. 
+The following steps guide an API Provider through setting up an API on the {{ glossary_tooltip text="API Services Portal" term_id="api-services-portal" }} in a Test/Training instance. 
 At the end of the guide, you will have a public API endpoint that is protected using the OAuth2 Client Credential Grant.
 
 ## 1. Download the `gwa` CLI

--- a/documentation/tutorials/quick-start.md
+++ b/documentation/tutorials/quick-start.md
@@ -12,7 +12,7 @@ publishDate: "2021-06-10T20:00:00.000-08:00"
 > NOTE: As of Sep 19, 2023, we have upgraded our command line interface to version 2, which is used in this tutorial. 
 > For a tutorial using v1 of the `gwa` CLI visit [API Provider User Journey v1](/guides/owner-journey-v1.md).
 
-The following steps guide an {{ glossary_tooltip text="API provider" term_id="api-provider" }} aka {{ glossary_tooltip term_id="api-provider" }} through setting up an API on the {{ glossary_tooltip term_id="api-services-portal" text="API Services Portal" }} in a Test/Training instance. 
+The following steps guide an {{ glossary_tooltip term_id="api-provider" }} through setting up an API on the {{ glossary_tooltip term_id="api-services-portal" text="API Services Portal" }} in a Test/Training instance. 
 At the end of the guide, you will have a public API endpoint that is protected using the OAuth2 Client Credential Grant.
 
 ## 1. Download the `gwa` CLI

--- a/documentation/tutorials/quick-start.md
+++ b/documentation/tutorials/quick-start.md
@@ -12,7 +12,7 @@ publishDate: "2021-06-10T20:00:00.000-08:00"
 > NOTE: As of Sep 19, 2023, we have upgraded our command line interface to version 2, which is used in this tutorial. 
 > For a tutorial using v1 of the `gwa` CLI visit [API Provider User Journey v1](/guides/owner-journey-v1.md).
 
-The following steps guide an API Provider through setting up an API on the {{ glossary_tooltip text="API Services Portal" term_id="api-services-portal" }} in a Test/Training instance. 
+The following steps guide an {{ glossary_tooltip term_id="api-provider" }} through setting up an API on the {{ glossary_tooltip text="API Services Portal" term_id="api-services-portal" }} in a Test/Training instance. 
 At the end of the guide, you will have a public API endpoint that is protected using the OAuth2 Client Credential Grant.
 
 ## 1. Download the `gwa` CLI
@@ -105,7 +105,7 @@ Gaining access involves requesting access (as a consumer of your API would), obt
 
 Start by going to the **Namespaces** tab in the API Services Portal and click the **Preview in Directory** link in the **Products** panel.
 
-You will see a card with the service name you chose earlier (`<MYSERVICE>`). This card is a preview of how the service would look when shared to the API Directory.
+You will see a card with the service name you chose earlier (`<MYSERVICE>`). This card is a preview of how the service would look when shared to the {{ glossary_tooltip term_id="api-directory" }}.
 
 Click the title, then click **Request Access**.
 

--- a/documentation/tutorials/quick-start.md
+++ b/documentation/tutorials/quick-start.md
@@ -12,7 +12,7 @@ publishDate: "2021-06-10T20:00:00.000-08:00"
 > NOTE: As of Sep 19, 2023, we have upgraded our command line interface to version 2, which is used in this tutorial. 
 > For a tutorial using v1 of the `gwa` CLI visit [API Provider User Journey v1](/guides/owner-journey-v1.md).
 
-The following steps guide an {{ glossary_tooltip term_id="api-provider" }} through setting up an API on the {{ glossary_tooltip text="API Services Portal" term_id="api-services-portal" }} in a Test/Training instance. 
+The following steps guide an {{ glossary_tooltip term_id="api-provider" }} through setting up an API on the {{ glossary_tooltip term_id="api-services-portal" text="API Services Portal" }} in a Test/Training instance. 
 At the end of the guide, you will have a public API endpoint that is protected using the OAuth2 Client Credential Grant.
 
 ## 1. Download the `gwa` CLI

--- a/documentation/tutorials/quick-start.md
+++ b/documentation/tutorials/quick-start.md
@@ -12,7 +12,7 @@ publishDate: "2021-06-10T20:00:00.000-08:00"
 > NOTE: As of Sep 19, 2023, we have upgraded our command line interface to version 2, which is used in this tutorial. 
 > For a tutorial using v1 of the `gwa` CLI visit [API Provider User Journey v1](/guides/owner-journey-v1.md).
 
-The following steps guide an {{ glossary_tooltip term_id="api-provider" }} through setting up an API on the {{ glossary_tooltip term_id="api-services-portal" text="API Services Portal" }} in a Test/Training instance. 
+The following steps guide an {{ glossary_tooltip text="API provider" term_id="api-provider" }} aka {{ glossary_tooltip term_id="api-provider" }} through setting up an API on the {{ glossary_tooltip term_id="api-services-portal" text="API Services Portal" }} in a Test/Training instance. 
 At the end of the guide, you will have a public API endpoint that is protected using the OAuth2 Client Credential Grant.
 
 ## 1. Download the `gwa` CLI

--- a/scripts/glossary_reference.yaml
+++ b/scripts/glossary_reference.yaml
@@ -64,7 +64,7 @@ terms:
     def: An environment in software development is the collection of hardware and software a system uses to run applications and services. These include development, testing, and production environments.
     url: 
   gwa-command-line-interface:
-    name: gwa Command Line Interface
+    name: `gwa` Command Line Interface
     def: The `gwa` command line interface (CLI) is a tool for creating and publishing Gateway Services and other resources on the API Management Portal. Resources are defined in YAML configuration files. The `gwa` CLI helps support automated Gateway management through scripting.
     url: 
   kong-gateway:

--- a/scripts/glossary_reference.yaml
+++ b/scripts/glossary_reference.yaml
@@ -64,7 +64,7 @@ terms:
     def: An environment in software development is the collection of hardware and software a system uses to run applications and services. These include development, testing, and production environments.
     url: 
   gwa-command-line-interface:
-    name: `gwa` Command Line Interface
+    name: "`gwa` Command Line Interface"
     def: The `gwa` command line interface (CLI) is a tool for creating and publishing Gateway Services and other resources on the API Management Portal. Resources are defined in YAML configuration files. The `gwa` CLI helps support automated Gateway management through scripting.
     url: 
   kong-gateway:

--- a/scripts/glossary_reference.yaml
+++ b/scripts/glossary_reference.yaml
@@ -18,7 +18,7 @@ terms:
   api-directory:
     name: API Directory
     def: Our API Directory is a centralized repository where API Providers can securely publish their APIs. API Consumers can find and request access to published APIs for integration in the API Directory.
-    url: 
+    url: {DOCS_URL}/concepts/api-directory
   api-gateway:
     name: API Gateway
     def: An API Gateway is a service that acts as a single entry point for multiple APIs, managing requests, routing, security, and other operations, simplifying and centralizing API management.

--- a/scripts/sub_glossary.py
+++ b/scripts/sub_glossary.py
@@ -45,10 +45,31 @@ def process_markdown_files(root_folder, definitions):
                 except Exception as e:
                     print("Error processing", markdown_file, ":", e)
 
-def main():
-    config_file = 'scripts/terms.yaml'
-    definitions = load_definitions(config_file)
+def yaml_to_md_glossary(yaml_file):
+    with open(yaml_file, 'r') as f:
+        data = yaml.safe_load(f)
+    
+    markdown_table = "---\ntitle: Glossary\n---\n\n|Term|Definition|\n|:----|:----|\n"
+    
+    for term, details in data['terms'].items():
+        markdown_table += f"|{details['name']}|{details['def']}|\n"
+    
+    return markdown_table
 
+def save_to_file(markdown_table, output_file):
+    with open(output_file, 'w') as f:
+        f.write(markdown_table)
+
+def main():
+    terms_file = 'scripts/terms.yaml'
+    definitions = load_definitions(terms_file)
+    
+    # produce glossary
+    markdown_table = yaml_to_md_glossary(terms_file)
+    output_file = 'documentation/reference/glossary.md'
+    save_to_file(markdown_table, output_file)
+
+    # substitute docs
     documentation_folder = 'documentation'
     process_markdown_files(documentation_folder, definitions)
 

--- a/scripts/sub_glossary.py
+++ b/scripts/sub_glossary.py
@@ -38,9 +38,9 @@ def process_markdown_files(root_folder, definitions):
             if file.endswith(".md"):
                 markdown_file = os.path.join(root, file)
                 try:
-                    # modified_content = substitute_links(markdown_file, definitions)
-                    # with open(markdown_file, 'w') as f:
-                    #     f.write(modified_content)
+                    modified_content = substitute_links(markdown_file, definitions)
+                    with open(markdown_file, 'w') as f:
+                        f.write(modified_content)
                     print("Links substituted successfully in", markdown_file)
                 except Exception as e:
                     print("Error processing", markdown_file, ":", e)

--- a/scripts/sub_glossary.py
+++ b/scripts/sub_glossary.py
@@ -22,7 +22,8 @@ def substitute_links(markdown_file, definitions):
             content = f.read()
 
         for term_id, term_data in definitions.items():
-            pattern = r'\{\{ glossary_tooltip(?: text="([^"]+)")? term_id="' + term_id + r'" \}\}'
+            pattern = r'\{\{ glossary_tooltip(?: term_id="([^"]+)"(?: text="([^"]+)")?| text="([^"]+)" term_id="' + term_id + r'") \}\}'
+
             matches = re.findall(pattern, content)
 
             for match in matches:

--- a/scripts/sub_glossary.py
+++ b/scripts/sub_glossary.py
@@ -26,12 +26,13 @@ def substitute_links(markdown_file, definitions):
             matches = re.findall(pattern, content)
 
             for match in matches:
-                term_text = match if match else term_data["name"]  # Use name if text is not provided
+                 # Use name if text is not provided
+                term_text = match if match else term_data["name"]
 
                 if term_data["url"]:
-                    link_tag = f'<a href="{term_data["url"]}" title="{term_data["def"]}" style="text-decoration: none !important; color: inherit; border-bottom: 1px dotted;">{term_text}</a>'
+                    link_tag = f'<a href="{term_data["url"]}" title="{term_data["def"]}" target="_blank" style="text-decoration: none !important; color: inherit; border-bottom: 1px dotted;">{term_text}</a>'
                 else:
-                    # Not actually a link, only tooltip
+                    # If no url, just create tooltip
                     link_tag = f'<span title="{term_data["def"]}" style="border-bottom: 1px dotted;">{term_text}</span>'
                 
                 # Replace the placeholder with the link tag

--- a/scripts/sub_glossary.py
+++ b/scripts/sub_glossary.py
@@ -23,7 +23,7 @@ def substitute_links(markdown_file, definitions):
 
             for match in matches:
                 # Create the link tag
-                link_tag = f'<a href="{term_data["url"]}" title="{term_data["def"]}" style="text-decoration: none !important; color: #000; border-bottom: 1px dotted #000;">{match}</a>'
+                link_tag = f'<a href="{term_data["url"]}" title="{term_data["def"]}" style="text-decoration: none !important; color: inherit; border-bottom: 1px dotted;">{match}</a>'
                 # Replace the placeholder with the link tag
                 content = re.sub(pattern, link_tag, content, count=1)
 

--- a/scripts/sub_glossary.py
+++ b/scripts/sub_glossary.py
@@ -22,8 +22,7 @@ def substitute_links(markdown_file, definitions):
             content = f.read()
 
         for term_id, term_data in definitions.items():
-            pattern = r'\{\{ glossary_tooltip(?: term_id="([^"]+)"(?: text="([^"]+)")?| text="([^"]+)" term_id="' + term_id + r'") \}\}'
-
+            pattern = r'\{\{ glossary_tooltip term_id="' + term_id + r'"\s*(?:text="([^"]+)")?\s*\}\}'            
             matches = re.findall(pattern, content)
 
             for match in matches:

--- a/scripts/sub_glossary.py
+++ b/scripts/sub_glossary.py
@@ -1,0 +1,56 @@
+import os
+import yaml
+import re
+import sys
+
+def load_definitions(config_file):
+    try:
+        with open(config_file, 'r') as f:
+            config = yaml.safe_load(f)
+            return config.get("terms", {})
+    except Exception as e:
+        print("Error loading configuration file:", e)
+        sys.exit(1)
+
+def substitute_links(markdown_file, definitions):
+    try:
+        with open(markdown_file, 'r') as f:
+            content = f.read()
+
+        for term_id, term_data in definitions.items():
+            pattern = r'\{\{ glossary_tooltip text="([^"]+)" term_id="' + term_id + r'" \}\}'
+            matches = re.findall(pattern, content)
+
+            for match in matches:
+                # Create the link tag
+                link_tag = f'<a href="{term_data["url"]}" title="{term_data["def"]}" style="text-decoration: none !important; color: #000; border-bottom: 1px dotted #000;">{match}</a>'
+                # Replace the placeholder with the link tag
+                content = re.sub(pattern, link_tag, content, count=1)
+
+        return content
+    except Exception as e:
+        print("Error substituting links in", markdown_file, ":", e)
+        sys.exit(1)
+
+def process_markdown_files(root_folder, definitions):
+    for root, dirs, files in os.walk(root_folder):
+        for file in files:
+            if file.endswith(".md"):
+                markdown_file = os.path.join(root, file)
+                try:
+                    # modified_content = substitute_links(markdown_file, definitions)
+                    # with open(markdown_file, 'w') as f:
+                    #     f.write(modified_content)
+                    print("Links substituted successfully in", markdown_file)
+                except Exception as e:
+                    print("Error processing", markdown_file, ":", e)
+
+def main():
+    config_file = 'scripts/terms.yaml'
+    definitions = load_definitions(config_file)
+
+    documentation_folder = 'documentation'
+    process_markdown_files(documentation_folder, definitions)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/terms.yaml
+++ b/scripts/terms.yaml
@@ -1,7 +1,117 @@
 terms:
+  access-control:
+    name: Access Control
+    def: Access control is a set of security measures that regulate who can access a system, services, data, or resource. Access control policies use {{ glossary_tooltip text="authentication" term_id="authentication" }} and {{ glossary_tooltip text="authorization" term_id="authorization" }} to verify users and enable access.
+    url: 
+  access-token:
+    name: Access Token
+    def: Access tokens enable clients to securely call protected APIs. The APIs use the access tokens to perform authentication and authorization. The information in the access token verifies that a user is entitled to access an API.
+    url: 
+  api:
+    name: API
+    def: An Application Programming Interface (API) is a software-to-software interface that provides a secure and standardized way for applications to communicate with each other to deliver requested data without user intervention.
+    url: 
+  api-consumer:
+    name: API Consumer
+    def: API Consumers (organizations providing services to end-users) use APIs in the delivery of their services. API Consumers integrate the APIs into their applications.
+    url: 
+  api-directory:
+    name: API Directory
+    def: Our API Directory is a centralized repository where API Providers can securely publish their APIs. API Consumers can find and request access to published APIs for integration in the API Directory.
+    url: 
+  api-gateway:
+    name: API Gateway
+    def: An API Gateway is a service that acts as a single entry point for multiple APIs, managing requests, routing, security, and other operations, simplifying and centralizing API management.
+    url: 
+  api-key:
+    name: API Key
+    def: A unique identifier used to authenticate a client application accessing an API. The API Key is included in each API request and used to identify the application and authorize the request.
+    url: 
+  api-program-services:
+    name: API Program Services (APS)
+    def: API Program Services (APS) is the team responsible for delivering services that enable ongoing access to public sector data by providing support for managing APIs in BC Government. APS ensures the efficient management of APIs through the API Services Portal.
+    url: 
+  api-provider:
+    name: API Provider
+    def: An API Provider, usually a developer, is someone who creates, publishes, operates, and maintains APIs in the API Management Platform.
+    url: 
+  api-management-platform:
+    name: API Management Platform
+    def: The API Management Platform is an overarching service that enables data providers to manage their APIs. It includes the API Services Portal and API Directory.
+    url: 
   api-services-portal:
-    def: A helpful tool for managing your APIs.
-    url: https://api.gov.bc.ca
-  gwa-cli:
-    def: Command line tool for creating and publishing gateway configuration.
-    url: https://dev.developer.gov.bc.ca/docs/default/component/aps-infra-platform-docs/resources/gwa-commands/
+    name: API Services Portal
+    def: The API Services Portal is the access point for API Providers and Consumers to publish, discover, and manage APIs. It is built using the open-source Kong Gateway and includes tools to provide API security, authentication, routing, and publishing. The API Services Portal enables API Providers to build, configure, and share their APIs publicly or privately.
+    url: 
+  authentication:
+    name: Authentication
+    def: Authentication is a security process for verifying the identity of a user or device before allowing access to a system, resource, or function. Authentication validates that a user or system is who they claim to be.
+    url: 
+  authorization:
+    name: Authorization
+    def: Authorization is a security process for providing a user or device with access to a requested system, resource, or function based on permissions. Authorization is provided only after a user or device has been authenticated.
+    url: 
+  client:
+    name: Client
+    def: In the context of an API, a client refers to a software application or system that accesses the functionality provided by the API. Clients send requests to and receive responses from the API.
+    url: 
+  client-secret:
+    name: Client Secret
+    def: A confidential code shared between a client application and the authorization server to generate an access token. Used in an OAuth Client Credentials flow, which enhances security by validating client identity.
+    url: 
+  environment:
+    name: Environment
+    def: An environment in software development is the collection of hardware and software a system uses to run applications and services. These include development, testing, and production environments.
+    url: 
+  gwa-command-line-interface:
+    name: gwa Command Line Interface
+    def: The `gwa` command line interface (CLI) is a tool for creating and publishing Gateway Services and other resources on the API Management Portal. Resources are defined in YAML configuration files. The `gwa` CLI helps support automated Gateway management through scripting.
+    url: 
+  kong-gateway:
+    name: Kong Gateway
+    def: Kong Gateway is an open-source, cloud-native API gateway. It is the centralized entry point for managing and securing APIs, and controlling access, traffic, and data transformation. When API Providers configure API Gateways for their services, these Gateways are enforced through Kong.
+    url: 
+  namespace:
+    name: Namespace
+    def: A namespace is a collection of Kong Gateway Services and Routes, generally managed by a single team or business unit.
+    url: 
+  organization:
+    name: Organization
+    def: An organization is any ministry, crown corporation, or agency within the B.C. Government.
+    url: 
+  organization-administrator:
+    name: Organization Administrator
+    def: An Organization Administrator (Org Admin) is the user responsible for monitoring and managing all APIs for a specific organization on the API Services Portal. The Org Admin’s primary responsibility is to allow an API provider to publish an API to the API Directory.
+    url: 
+  publish:
+    name: Publish
+    def: Publishing APIs is the process by which an API Provider makes their API publicly available in the API Directory for discovery by API Consumers.
+    url: 
+  rate-limit:
+    name: Rate Limit
+    def: A way to restrict how many times a user, bot, or application can access an API in a given timeframe. Rate limiting is important for preventing malicious attacks.
+    url: 
+  role:
+    name: Role
+    def: A role is a group of predefined access permissions assigned to a user.
+    url: 
+  route:
+    name: Route
+    def: A route is a means of exposing a service to users. It is the path used to send requests to its respective service after reaching the Gateway. A single service can have multiple routes.
+    url: 
+  service:
+    name: Service
+    def: A service represents an external upstream API or microservice consisting of a URL, which listens for incoming requests.
+    url: 
+  scope:
+    name: Scope
+    def: Scope is a method used to specify authorization, or a set of permissions that grant access to specified systems and actions. Scopes can be applied to both users and service accounts.
+    url: 
+  shared-idp:
+    name: Shared IdP
+    def: An Identity Provider (IdP) is a service that stores, maintains, and manages digital identities to authenticate users logging into an application. The API Services Portal uses a Shared IdP, which is a centralized BC Government IdP (SSO Gold-tier Keycloak cluster) that manages credentials and user access. The Shared IdP enables entities (APIs, applications, websites, and services) to access secured digital identities to control authentication and authorization. By using a Shared IdP, the API Services Portal enables API providers to delegate the responsibility of authentication and authorization to their chosen IdP (including IDIR, BC Services Card, GitHub ID).
+    url: 
+  yaml-file:
+    name: YAML File
+    def: YAML is a computer language used to create simple-to-read configuration files. The API Services Portal can use YAML files to store and publish configuration for all object types (for example, Gateway Services, Datasets, Products, etc.). YAML is structured using indents and minimal punctuation marks, and usually has a file extension of `.yaml` or `.yml`.
+    url: 

--- a/scripts/terms.yaml
+++ b/scripts/terms.yaml
@@ -1,0 +1,7 @@
+terms:
+  api-services-portal:
+    def: A helpful tool for managing your APIs.
+    url: https://api.gov.bc.ca
+  gwa-cli:
+    def: Command line tool for creating and publishing gateway configuration.
+    url: https://dev.developer.gov.bc.ca/docs/default/component/aps-infra-platform-docs/resources/gwa-commands/


### PR DESCRIPTION
Implements a Python script which runs before techdocs build to add glossary tooltips + links

In addition to adding the script and modifying the publish GHA, this required:
- reformat glossary to a structured format which suits use in the script
- recreate the glossary page for publication

Usage is explained in https://github.com/bcgov/aps-infra-platform/blob/APS-2409-sub-glossary/README.md#insert-glossary-term-references

I tried to get links to open in new tab but target="_blank" does not work for internal links apparently.

Example usage is shown in https://github.com/bcgov/aps-infra-platform/blob/APS-2409-sub-glossary/documentation/tutorials/quick-start.md?plain=1#L15 and https://github.com/bcgov/aps-infra-platform/blob/APS-2409-sub-glossary/documentation/tutorials/quick-start.md?plain=1#L108.

--

I also modified the publish GHA so you can theoretically publish any branch to prod from a manual `workflow_dispatch` (ie the option works as advertised).