### PR TITLE
Fix "owner" value so links to team page work properly in DevHub

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: documentation
   lifecycle: production
-  owner: "databc-aps"
+  owner: "bcgov/databc-aps"


### PR DESCRIPTION
Fix "owner" value so links to team page work properly in DevHub. Currently, the link to team owning the APS docs is broken in Devhub. This change will fix so it displays.a team details page when clicked.