### PR TITLE
APS-3138 - Add to custom domain + gw config formats

### DIFF
--- a/documentation/concepts/gateway-config.md
+++ b/documentation/concepts/gateway-config.md
@@ -111,13 +111,15 @@ resource-based format is recommended for its flexibility and support for
 additional resource types.
 
 ### Key differences between formats
-| Attribute                                                                       | Legacy                   | Resource-based |
+
+| Format                                                                       | Legacy                   | Resource-based |
 |------------------------------------------------------------------------------|--------------------------|----------------|
 | Supports GatewayService configuration                                        | ✅                        | ✅              |
 | Supports SSL certificates                                                    | ✅                        | ❌              |
 | Supports additional resource types (Product, DraftDataset, CredentialIssuer) | ❌                        | ✅              |
 | Publish command                                                              | `publish-gateway` (`pg`) | `apply`        |
-| Minimum `gwa` CLI version                                                    | v1.0.0                      | v2.0.4             |
+| Format produced by `gwa generate-config` templates                           | ❌                        | ✅              |
+| Minimum `gwa` CLI version                                                    | N/A                      | v2             |
 
 ## Configuration update behaviour
 

--- a/documentation/concepts/gateway-config.md
+++ b/documentation/concepts/gateway-config.md
@@ -69,7 +69,7 @@ to add custom headers.
 
 There are two Gateway configuration formats that can be used:
 
-- **Legacy format:** Introduced with v1 of the `gwa` CLI. This format supports
+- **Kong format:** Introduced with v1 of the `gwa` CLI. This format supports
   only basic GatewayService configuration.
 
   ```yaml
@@ -112,7 +112,7 @@ additional resource types.
 
 ### Key differences between formats
 
-| Format                                                                       | Legacy                   | Resource-based |
+| Format                                                                       | Kong                   | Resource-based |
 |------------------------------------------------------------------------------|--------------------------|----------------|
 | Supports GatewayService configuration                                        | ✅                        | ✅              |
 | Supports SSL certificates                                                    | ✅                        | ❌              |
@@ -124,7 +124,7 @@ additional resource types.
 ## Configuration update behaviour
 
 The configuration update behaviour depends on the type of resource and applies
-to both legacy and resource-based formats.
+to both Kong and resource-based formats.
 
 ### Gateway Service Configuration
 

--- a/documentation/concepts/gateway-config.md
+++ b/documentation/concepts/gateway-config.md
@@ -65,6 +65,92 @@ This configuration defines a service `example-service-dev` with a corresponding
 route `example-service-route` and applies a `request-transformer` plugin to it
 to add custom headers.
 
+## Gateway configuration formats
+
+There are two Gateway configuration formats that can be used:
+
+- **Legacy format:** Introduced with v1 of the `gwa` CLI. This format supports
+  only basic GatewayService configuration.
+
+  ```yaml
+  services:
+    - name: example-service-1
+      host: httpbin.org
+      ...
+    - name: example-service-2
+      host: httpbin.org
+      ...
+  ```
+
+- **Resource-based format:** An updated format introduced with v2 of `gwa`. This
+  format supports additional resource types for the API Services Portal.
+  Individual resources are separated by `---`.
+
+  ```yaml
+  kind: GatewayService
+  name: example-service-1
+  host: httpbin.org
+  ...
+
+  ---
+  kind: GatewayService
+  name: example-service-2
+  host: httpbin.org
+  ...
+
+  ---
+  kind: Product
+  name: example-product
+  ...
+  ```
+
+Unless you need to load SSL certificates to support [custom
+domains](/how-to/custom-domain) or
+[mTLS](/how-to/upstream-services.md#verify-upstream-services-with-mtls), the
+resource-based format is recommended for its flexibility and support for
+additional resource types.
+
+### Key differences between formats
+| Attribute                                                                       | Legacy                   | Resource-based |
+|------------------------------------------------------------------------------|--------------------------|----------------|
+| Supports GatewayService configuration                                        | ✅                        | ✅              |
+| Supports SSL certificates                                                    | ✅                        | ❌              |
+| Supports additional resource types (Product, DraftDataset, CredentialIssuer) | ❌                        | ✅              |
+| Publish command                                                              | `publish-gateway` (`pg`) | `apply`        |
+| Minimum `gwa` CLI version                                                    | v1.0.0                      | v2.0.4             |
+
+## Configuration update behaviour
+
+The configuration update behaviour depends on the type of resource and applies
+to both legacy and resource-based formats.
+
+### Gateway Service Configuration
+
+For Gateway Services, the configuration is **declarative**:
+- The provided configuration represents the exact state of the Gateway Services
+  that will be set up.
+- In the resource-based format, if no `kind: GatewayService` resources are
+  included, the Gateway Service configuration will remain unchanged.
+
+!!! note "Clearing Gateway Service configuration"
+    To clear all Gateway Service configuration, create a YAML file with the following content:
+    ```yaml
+    services: []
+    ```
+ 
+### Other resource types
+
+For other resource types, such as Product, DraftDataset, or CredentialIssuer:
+
+- If no resource with the same `name` exists, a new resource will be created. 
+- If a resource with the same `name` exists, it will be updated with the provided configuration.
+
+This provides flexibility for managing non-GatewayService resources without
+requiring a complete declaration of their current state.
+
+Deleting other resource types is not supported via the `gwa` CLI. 
+Use the API Services Portal to delete Products, ProductEnvironments, and CredentialIssuers.
+
 ## Next steps
 
 If you would like to dive deeper or start implementing a Gateway Configuration,

--- a/documentation/how-to/custom-domain.md
+++ b/documentation/how-to/custom-domain.md
@@ -101,11 +101,46 @@ Publish your Gateway Service with custom domain using the following command:
 gwa pg gw-config.yaml
 ```
 
+## Configure DNS for your custom domain
+
+You will need to add a DNS record for your custom domain pointing to the OpenShift cluster where your Gateway is deployed.
+
+### Silver cluster
+
+By default, new Gateways are created on the Silver cluster. Create an A record
+for your custom domain pointing to `142.34.194.118`, Silver's ingress IP
+address.
+
+### Gold cluster
+
+Gold cluster route hosts will resolve to `142.34.229.4` or `142.34.64.4`
+depending on whether the APS service is in Gold (Kamloops) or for disaster
+recovery in Gold DR (Calgary).
+
+To ensure routing to the appropriate cluster, create a CNAME record for your
+custom domain pointing to `ggw.api.gov.bc.ca.glb.gov.bc.ca`, APS's Global Load
+Balancer.
+
+### Emerald cluster
+
+Emerald cluster route hosts will be assigned an IP address depending on the data
+class that was specified in the Gateway Service.
+
+[Contact the APS team](README.md#need-a-hand) to get the IP address for your
+routes. This IP address will not change for the route unless the data class
+changes.
+
+Once you have the IP address, create an A record for your custom domain pointing
+to the IP address.
+
 ## Access your API (Validation)
 
-After publishing your Gateway Service, you can access your API by visiting the URL of your Gateway Service.
+After publishing your Gateway Service and configuring DNS, you can access your
+API by visiting the URL of your Gateway Service.
 
-You can expect to see upstream API responses in the browser, or if you used the placeholder `httpbin.org` in the Gateway Service configuration, you will see the contents of the httpbin.org homepage.
+You can expect to see upstream API responses in the browser, or if you used the
+placeholder `httpbin.org` in the Gateway Service configuration, you will see the
+contents of the httpbin.org homepage.
 
 <!-- whatsnext -->
 

--- a/documentation/how-to/custom-domain.md
+++ b/documentation/how-to/custom-domain.md
@@ -88,7 +88,7 @@ Where:
 
 !!! warning "Gateway configuration formats"
     There are [two formats for Gateway configuration](/concepts/gateway-config.md#gateway-configuration-formats).
-    To include SSL certificates in your Gateway Service configuration, you must use the **legacy format**, as shown above.   
+    To include SSL certificates in your Gateway Service configuration, you must use the **Kong format**, as shown above.   
 
     To publish other resource types (Product, Dataset, etc.), you can maintain a separate 
     YAML file using the resource-based format and publish it using the `gwa apply` command. 

--- a/documentation/how-to/custom-domain.md
+++ b/documentation/how-to/custom-domain.md
@@ -14,16 +14,32 @@ Before you begin, ensure you:
 
 - [Install gwa CLI](/how-to/gwa-install.md)
 - [Create a Gateway](/how-to/create-gateway.md)
+- Register your custom domain and obtain SSL certificates
 
 <!-- steps -->
 
-## Create a Gateway Service with a Custom Domain
+## Submit a request with APS
 
-If you have already created a Gateway Service in [Create a Gateway Service](/how-to/create-gateway-service.md) 
-or [Quick Start](/tutorials/quick-start.md) using the `gwa generate-config` command, you will need to extract 
-the Gateway Service information into a separate YAML file and reformat as shown below.
+Routing to a custom domain requires special permissions for your Gateway. Reach
+out to the APS team on Rocket.Chat in the
+[#aps-ops](https://chat.developer.gov.bc.ca/channel/aps-ops) channel or [open a
+support
+ticket](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/2). You will need to provide the fully qualified domain name (FQDN) and the `gatewayId` for your Gateway.
 
-Example configuration:
+The APS team will also create a DNS record for your custom domain pointing to
+the OpenShift cluster where your Gateway is deployed. See [Set Up an Upstream
+Service](/how-to/upstream-services) for more information on the available
+clusters.
+
+## Create a Gateway Service
+
+Creating a Gateway Service with a custom domain is much the same as creating a
+Gateway Service without a custom domain. The key difference is the inclusion of
+SSL certficiates in the `certificates` section.
+
+For more general information on creating Gateway Services, see [Create a Gateway Service](/how-to/create-gateway-service.md).
+
+Add the `certificates` section to your Gateway Service configuration as shown in this example:
 
 ```yaml
 certificates:
@@ -70,18 +86,26 @@ Where:
   python3 -c 'import uuid; print(uuid.uuid4())'
   ```
 
-## Publish Gateway Service with Custom Domain
+!!! warning "Gateway configuration formats"
+    There are [two formats for Gateway configuration](/concepts/gateway-config.md#gateway-configuration-formats).
+    To include SSL certificates in your Gateway Service configuration, you must use the **legacy format**, as shown above.   
 
-When using a custom domain, you will need to maintain two separate YAML files. One will contain the 
-certificate details and Gateway Service configuration (seen above), and will be applied using the `gwa pg` 
-command. The other will contain any Portal resources (Product, Dataset, etc.) you define, and will be 
-applied using the `gwa apply` command.
+    To publish other resource types (Product, Dataset, etc.), you can maintain a separate 
+    YAML file using the resource-based format and publish it using the `gwa apply` command. 
+
+## Publish Gateway Service
 
 Publish your Gateway Service with custom domain using the following command:
 
 ```shell linenums="0"
-gwa pg gw.yaml
+gwa pg gw-config.yaml
 ```
+
+## Access your API (Validation)
+
+After publishing your Gateway Service, you can access your API by visiting the URL of your Gateway Service.
+
+You can expect to see upstream API responses in the browser, or if you used the placeholder `httpbin.org` in the Gateway Service configuration, you will see the contents of the httpbin.org homepage.
 
 <!-- whatsnext -->
 

--- a/documentation/how-to/private-route.md
+++ b/documentation/how-to/private-route.md
@@ -21,11 +21,10 @@ This page shows how to configure a private route for a service.
 
 ## Submit a request with APS
 
-Reach out to the APS team on Rocket.Chat in the
+Creating private routes requires special permissions for your Gateway. Reach out to the APS team on Rocket.Chat in the
 [#aps-ops](https://chat.developer.gov.bc.ca/channel/aps-ops) channel or [open a
 support
-ticket](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/2) to get
-permission to create a local cluster route.
+ticket](https://dpdd.atlassian.net/servicedesk/customer/portal/1/group/2). You will need to provide the `gatewayId` for your Gateway.
 
 ## Configure the route
 

--- a/documentation/how-to/upstream-services.md
+++ b/documentation/how-to/upstream-services.md
@@ -164,7 +164,7 @@ For more information on the Emerald cluster and security classifications, see th
 
 Emerald cluster route hosts will be assigned an IP address depending on the data class that was specified in the Gateway Service.
 
-You will need to [contact the APS team](README.md#need-a-hand) to get the IP address that was assigned for your routes.  This IP address will not change for the route unless the data class changes.
+[Contact the APS team](README.md#need-a-hand) to get the IP address for your routes.  This IP address will not change for the route unless the data class changes.
 
 #### Network policies for upstream
 

--- a/documentation/how-to/upstream-services.md
+++ b/documentation/how-to/upstream-services.md
@@ -199,7 +199,7 @@ spec:
 Where:
 
 - `podSelector` is a selector that matches your upstream service.
-- `namespaceSelector` is the APS namespace which hosts the API Gateway on Silver (`b8840c`), not your namespace. Don't change this.
+- `namespaceSelector` is the APS namespace which hosts the API Gateway on Emerald (`cc9a8a`), not your namespace. Don't change this.
 
 **Upstream egress policy**: APS will also create an `egress` Network Policy to send traffic from the API Gateway to the upstream service.
 


### PR DESCRIPTION
Q: For custom custom domains, will we handle DNS for clients in any cases? In all cases? Normally, we take care of DNS for Gold and we intend to do so for Emerald. What if users have a custom domain on these clusters? What about custom domains on Silver cluster?

In the current version of the docs, I have assumed that we will take care of DNS regardless of cluster at the same time we add the `perm-domains` permission. We should add to client onboarding docs to show a DNS entry for a custom domain on the Silver data plane.
 