### PR TITLE
Update publish-techdocs.yaml

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: 0
 
       - name: Determine deployment environment
         run: |

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
 
       - name: Determine deployment environment
         run: |


### PR DESCRIPTION
The `git-revision-date-localized` plugin used in the [mkdocs.yml](https://github.com/bcgov/aps-infra-platform/blob/38ba8b31f826b2982ce0b116b7153ed8e1e39b47/mkdocs.yml#L78) file requires [that fetch-depth be set to 0](https://github.com/timvink/mkdocs-git-revision-date-localized-plugin?tab=readme-ov-file#note-when-using-build-systems-like-github-actions) in order to function correctly. 

This change is to set that value.