### PR TITLE
APS-4452 new details for org signing

### DIFF
--- a/documentation/concepts/secure-data-exchange.md
+++ b/documentation/concepts/secure-data-exchange.md
@@ -30,7 +30,6 @@ following resources:
 How-to guides
 
 - [Onboarding an organization onto SDX](/how-to/sdx-org-onboarding.md)
-- [Provision a new Runtime Group (Edge Server)](/how-to/sdx-edge-servers.md)
+- [Provision a Runtime Group (Edge Server)](/how-to/sdx-edge-servers.md)
 - [Managing systems and services](/how-to/sdx-subsystems.md)
-- [Setup organization signing](/how-to/sdx-org-signing.md)
 - [Connecting a Service](/how-to/sdx-connections.md)

--- a/documentation/concepts/secure-data-exchange.md
+++ b/documentation/concepts/secure-data-exchange.md
@@ -30,6 +30,8 @@ following resources:
 How-to guides
 
 - [Onboarding an organization onto SDX](/how-to/sdx-org-onboarding.md)
-- [Provision a Runtime Group (Edge Server)](/how-to/sdx-edge-servers.md)
+- [Install a runtime group](/how-to/sdx-edge-servers.md)
 - [Managing systems and services](/how-to/sdx-subsystems.md)
 - [Connecting a Service](/how-to/sdx-connections.md)
+- [Event Mgmt (preview)](/how-to/sdx-ape-event-mgmt.md)
+- [Policy Mgmt (preview)](/how-to/sdx-ape-policy-mgmt.md)

--- a/documentation/how-to/sdx-ape-event-mgmt.md
+++ b/documentation/how-to/sdx-ape-event-mgmt.md
@@ -1,0 +1,141 @@
+---
+title: "Event Management"
+---
+
+This page shows how to publish an AsyncAPI service that can be used to publish messages
+and for consumers to setup webhooks to receive messages.
+
+!!! warning "Preview"
+
+    This feature is in `preview` only, which means it is experimental.
+    It is available in our `LAB` environment as is.
+
+The steps described in this page are performed by the following roles:
+
+| Role         | Function                                                                   |
+| ------------ | -------------------------------------------------------------------------- |
+| System Owner | Manage systems and service catalog entries for the particular organization |
+
+Use cases:
+
+- Register an async service
+- Configure a publisher endpoint
+- Connecting a service
+- Configure a webhook
+- Publishing a message
+
+## Prerequisites
+
+- [Install Restish CLI](/reference/restish-cli.md)
+
+## Register an async service
+
+=== "Restish CLI"
+
+    Help information about the operation:
+
+    ```sh
+    restish sdx create-oas-service
+    ```
+
+    Example:
+
+    ```sh
+    restish sdx create-oas-service \
+      ministry-of-citz \
+      --subsystem MY-NEW-SUBSYSTEM \
+      --rsh-header "Content-Type: application/json" \
+      < asyncapi.yaml
+    ```
+
+## Configure a publisher endpoint
+
+This sets up a protected URL that can be used by the Resource Server to publish messages
+on the topics described in the AsyncAPI.
+
+=== "Restish CLI"
+
+    Help information about the operation:
+
+    ```sh
+    restish sdx generate-config-from-pattern
+    ```
+
+    Example call:
+
+    ```sh
+    restish sdx generate-config-from-pattern \
+      ministry-of-citz \
+      --action apply --dry-run=false \
+      'pattern:events-publisher.r1, parameters:{ service_id: "LAB.USR.ACOPE.HELLO-WORLD-APPLICATION.v0" }'
+    ```
+
+    The output from this call will be a `publisher_url` that the Resource
+    Server will be able to call to send messages.
+
+## Connecting a service
+
+With the async service published, clients can request access to the AsyncAPI service.
+
+All the same security controls that are in place for OpenAPIs, are also available for AsyncAPIs.
+
+The how to guide for making connections is at [Connecting a Service](/how-to/sdx-connections.md).
+
+## Configure a webhook
+
+Once a connection has been approved, the client is able to configure the webhook
+details so that it can start to receive messages from the publisher.
+
+=== "Restish CLI"
+
+    Help information about the operation:
+
+    ```sh
+    restish sdx generate-config-from-pattern
+    ```
+
+    Example call:
+
+    ```sh
+    echo '
+      {
+        "pattern": "events-webhook.r1",
+        "parameters": {
+          "conn_id": "42",
+          "client_id": "LAB.MIN.CITZ.SDG-FE",
+          "service_id": "LAB.USR.ACOPE.HELLO-WORLD-APPLICATION.v0",
+          "webhook_url": "https://bright-island-08.webhook.cool"
+        }
+      }' | \
+    restish sdx generate-config-from-pattern \
+      ministry-of-citz \
+      --action apply --dry-run=false
+
+    ```
+
+## Publishing a message
+
+The RS published an AsyncAPI spec to state all the events it will publish.
+
+The RS will use its local Edge Server consumer endpoint to send a message.
+It will eventually require a valid token.
+
+```sh
+curl -v -H "Host:internal.share0.servers.sdx" \
+  http://localhost:8000/sdx/1/815a243837865c1ed61e94c0/messages \
+  -H "Content-Type: application/json" \
+  -d '{"value":{"note":"return it!"}}'
+```
+
+The return, if successful, is a `202 Accepted`, payload:
+
+```json
+{
+  "topicName": "Event-LAB.USR.ACOPE.HELLO-WORLD-APPLICATION.v0",
+  "partition": 0,
+  "errorCode": 0,
+  "baseOffset": "0",
+  "logAppendTime": "-1",
+  "logStartOffset": "0"
+}
+```

--- a/documentation/how-to/sdx-ape-event-mgmt.md
+++ b/documentation/how-to/sdx-ape-event-mgmt.md
@@ -117,7 +117,7 @@ details so that it can start to receive messages from the publisher.
 
 The RS published an AsyncAPI spec to state all the events it will publish.
 
-The RS will use its local Edge Server consumer endpoint to send a message.
+The RS will use its local runtime group consumer endpoint to send a message.
 It will eventually require a valid token.
 
 ```sh

--- a/documentation/how-to/sdx-ape-policy-mgmt.md
+++ b/documentation/how-to/sdx-ape-policy-mgmt.md
@@ -66,8 +66,6 @@ step.
 ```json
 {
     "upgrades": {
-      "sign": {},
-      "_co-sign": {},
       "pep": {
         "policy_name": "authz"
       }
@@ -80,7 +78,7 @@ The data source (policy information point) is a powerful way of pulling in autho
 data to be used in the decision making. The `upstream_url` should be accessible from the
 runtime group that the subsystem is registered on.
 
-```sh
+```json
 {
   "pattern": "opal-data-source.r1",
   "parameters": {
@@ -94,7 +92,7 @@ runtime group that the subsystem is registered on.
 For referencing the data source in your policy, use the `subsystem_id` package convention:
 
 ```sh
-import data.tenant["LAB.USR.ACOPE.APS-KAFKA"] as dat`
+import data.tenant["LAB.USR.ACOPE.APS-KAFKA"] as dat
 
 items := {row |
     row := dat["user-gateways"]

--- a/documentation/how-to/sdx-ape-policy-mgmt.md
+++ b/documentation/how-to/sdx-ape-policy-mgmt.md
@@ -1,0 +1,102 @@
+---
+title: "Policy Management"
+---
+
+This page shows how to create OPA and CEDAR policies and use them for enforcement on SDX.
+
+!!! warning "Preview"
+
+    This feature is in `preview` only, which means it is experimental.
+    It is available in our `LAB` environment as is.
+
+The steps described in this page are performed by the following roles:
+
+| Role         | Function                                                                   |
+| ------------ | -------------------------------------------------------------------------- |
+| System Owner | Manage systems and service catalog entries for the particular organization |
+
+Use cases:
+
+- Register a policy
+- Upgrade connection with a PEP
+- Register a data source
+
+## Register a policy
+
+> NOTE: The package name in the policy should match the `subsystem_id` (with `.` and `-` changed to `_`)
+> For example: `package LAB_USR_ACOPE_APS_KAFKA.authz`
+
+```sh
+{
+  "pattern": "opal-policy.r1",
+  "parameters": {
+    "subsystem_id": "LAB.USR.ACOPE.APS-KAFKA",
+    "name": "authz",
+    "policy": {{POLICY}}
+  }
+}
+```
+
+### Inputs
+
+When designing your policies, assume the `pep` plugin will provide
+the following data about the particular request:
+
+```json
+{
+  "method": "GET",
+  "path": "/v1/widgets/1234",
+  "named_params": {
+    "id": "1234"
+  },
+  "token": {
+    "sub": "111",
+    "aud": "abc",
+    "scopes": "scope1 scope2"
+  }
+}
+```
+
+## Upgrade connection with a PEP
+
+When configuring the `sdx-p2p-*.r1` gateway patterns for consumer and provider,
+use the `pep` upgrade to run the particular policy that you created in the previous
+step.
+
+```json
+{
+    "upgrades": {
+      "sign": {},
+      "_co-sign": {},
+      "pep": {
+        "policy_name": "authz"
+      }
+    }
+```
+
+## Register a data source
+
+The data source (policy information point) is a powerful way of pulling in authorization
+data to be used in the decision making. The `upstream_url` should be accessible from the
+runtime group that the subsystem is registered on.
+
+```sh
+{
+  "pattern": "opal-data-source.r1",
+  "parameters": {
+    "subsystem_id": "LAB.USR.ACOPE.APS-KAFKA",
+    "name": "user-gateways",
+    "upstream_url": "https://httpbun.com/any"
+  }
+}
+```
+
+For referencing the data source in your policy, use the `subsystem_id` package convention:
+
+```sh
+import data.tenant["LAB.USR.ACOPE.APS-KAFKA"] as dat`
+
+items := {row |
+    row := dat["user-gateways"]
+}
+```

--- a/documentation/how-to/sdx-connections.md
+++ b/documentation/how-to/sdx-connections.md
@@ -155,7 +155,8 @@ routing rules for opening a channel between the two systems.
     }
     ```
 
-For details on configuring the p2p pattern, go to [P2P Gateway Pattern Upgrades](/how-to/sdx-upgrades.md).
+For details on configuring the `sdx-p2p-consumer.r1` pattern,
+go to [Connection Gateway Patterns](/how-to/sdx-upgrades.md).
 
 ### Provider side
 
@@ -228,4 +229,5 @@ For details on configuring the p2p pattern, go to [P2P Gateway Pattern Upgrades]
     }
     ```
 
-For details on configuring the p2p pattern, go to [P2P Gateway Pattern Upgrades](/how-to/sdx-upgrades.md).
+For details on configuring the `sdx-p2p-provider.r1` pattern,
+go to [Connection Gateway Patterns](/how-to/sdx-upgrades.md).

--- a/documentation/how-to/sdx-connections.md
+++ b/documentation/how-to/sdx-connections.md
@@ -155,14 +155,7 @@ routing rules for opening a channel between the two systems.
     }
     ```
 
-Available upgrades for the `sdx-p2p-consumer.r1` pattern:
-
-```json
-{
-  "sign": {},
-  "verify": {}
-}
-```
+For details on configuring the p2p pattern, go to [P2P Gateway Pattern Upgrades](/how-to/sdx-upgrades.md).
 
 ### Provider side
 
@@ -184,9 +177,7 @@ Available upgrades for the `sdx-p2p-consumer.r1` pattern:
         "client_id": "LAB.MIN.CITZ.MY-SUBSYSTEM",
         "service_id": "LAB.MIN.CITZ.SERVICE-A.v1",
         "upstream_url": "https://my-upstream-endpoint.domain",
-        "upgrades": {
-          "sign": {}
-        }
+        "upgrades": {}
       }
     }
     ```
@@ -237,17 +228,4 @@ Available upgrades for the `sdx-p2p-consumer.r1` pattern:
     }
     ```
 
-Available upgrades for the `sdx-p2p-provider.r1` pattern:
-
-```json
-{
-  "sign": {},
-  "verify": {},
-  "token_exchange": {
-    "token_endpoint": "",
-    "client_id": "",
-    "scopes": "",
-    "audience": ""
-  }
-}
-```
+For details on configuring the p2p pattern, go to [P2P Gateway Pattern Upgrades](/how-to/sdx-upgrades.md).

--- a/documentation/how-to/sdx-edge-servers.md
+++ b/documentation/how-to/sdx-edge-servers.md
@@ -1,8 +1,12 @@
 ---
-title: Provision a new Edge Server
+title: Provision a Runtime Group (Edge Server)
 ---
 
-This page shows how to provision a new Edge Server (Runtime Group) on the SDX Ecosystem.
+This page shows how to provision an Edge Server (Runtime Group) on the SDX Ecosystem.
+
+Before your systems can start to connect with other systems in SDX, your organization must
+either deploy an Edge Server in your own infrastructure (client-hosted), or you must signup
+for using one of the shared Edge Servers (community-hosted).
 
 The steps described in this page are performed by the following roles:
 
@@ -10,7 +14,11 @@ The steps described in this page are performed by the following roles:
 | ------------ | ------------------------------------------------------------------ |
 | System Owner | Request a new edge server, and manage onboarding a new edge server |
 
-Use cases:
+Use cases for community-hosted:
+
+- Signup to a community-hosted Edge Server
+
+Use cases for client-hosted:
 
 - Register a new Runtime Group
 - Request a one-time-use certificate signing token
@@ -21,6 +29,12 @@ Use cases:
 ## Prerequisites
 
 - [Install Restish CLI](/reference/restish-cli.md)
+
+## Signup to a community-hosted Edge Server
+
+There are two community-hosted Edge Server on Silver (edge_s) and Gold (edge_g).
+
+To signup to them, please reach out to the SDX Operation team.
 
 ## Register a new Runtime Group
 
@@ -163,3 +177,7 @@ to add the public key using the certificate from the runtime group.
   }
 }
 ```
+
+## Next steps
+
+- [Setup Organization Signing](/how-to/sdx-org-signing.md)

--- a/documentation/how-to/sdx-edge-servers.md
+++ b/documentation/how-to/sdx-edge-servers.md
@@ -1,42 +1,57 @@
 ---
-title: Provision a Runtime Group (Edge Server)
+title: Install a Runtime Group
 ---
 
-This page shows how to provision an Edge Server (Runtime Group) on the SDX Ecosystem.
+This page shows how to install a runtime group for your organization on SDX.
 
 Before your systems can start to connect with other systems in SDX, your organization must
-either deploy an Edge Server in your own infrastructure (client-hosted), or you must signup
-for using one of the shared Edge Servers (community-hosted).
+either deploy a runtime group in your own infrastructure (`client-hosted`), or you must signup
+for using one of the shared runtime groups (`community-hosted`).
 
 The steps described in this page are performed by the following roles:
 
-| Role         | Function                                                           |
-| ------------ | ------------------------------------------------------------------ |
-| System Owner | Request a new edge server, and manage onboarding a new edge server |
+| Role         | Function                                                               |
+| ------------ | ---------------------------------------------------------------------- |
+| System Owner | Request a new runtime group, and manage onboarding a new runtime group |
 
-Use cases for community-hosted:
+!!! note "Community Hosted"
 
-- Signup to a community-hosted Edge Server
+    If you are going to use one of the `community-hosted` runtime groups, please
+    reach out to the APS team, and skip this how-to guide.
 
-Use cases for client-hosted:
+Use cases for `client-hosted`:
 
-- Register a new Runtime Group
+- Register a new runtime group
 - Request a one-time-use certificate signing token
-- Deploy Runtime Group infrastructure
-- Initialize default route policies
+- Deploy the runtime group infrastructure
+- Apply default routes and controls
+- Verification test
 - Add public key to registry
 
 ## Prerequisites
 
 - [Install Restish CLI](/reference/restish-cli.md)
 
-## Signup to a community-hosted Edge Server
+## Register a new runtime group
 
-There are two community-hosted Edge Server on Silver (edge_s) and Gold (edge_g).
+To register a runtime group, you need to know the internet-facing IP address that
+will be used to route traffic to this runtime group.
 
-To signup to them, please reach out to the SDX Operation team.
+=== "Restish CLI"
 
-## Register a new Runtime Group
+    Help information about the operation to list available runtimes:
+
+    ```sh
+    restish sdx create-runtime-group
+    ```
+
+    Example:
+
+    ```sh
+    restish sdx create-runtime-group \
+      ministry-of-citz \
+      'name: newrg, hostedOrganizations: ["ministry-of-citz"], sdxEndpoint: "https://142.34.194.118:443"'
+    ```
 
 === "Reference"
 
@@ -66,8 +81,10 @@ To signup to them, please reach out to the SDX Operation team.
 
 ## Request a one-time-use certificate signing token
 
-The Runtime Group infrastructure uses a token from the CA to bootstrap
+The runtime group infrastructure uses a token from the CA to bootstrap
 the first certificate.
+
+The certificate is used from supporting `mTLS` between runtime groups.
 
 This is performed by a System Owner to request a new cert signing token.
 
@@ -83,7 +100,7 @@ This is performed by a System Owner to request a new cert signing token.
 
     ```sh
     restish sdx generate-one-time-use-token \
-      ministry-of-citz abc123
+      ministry-of-citz newrg
     ```
 
 === "Reference"
@@ -98,9 +115,13 @@ This is performed by a System Owner to request a new cert signing token.
 It will return a token which can be extracted and stored in a local file
 for the next step.
 
-## Deploy Runtime Group infrastructure
+## Deploy the runtime group infrastructure
 
-The runtime group is deployed using a helm chart.
+We have a helm chart available for deploying a runtime group into a Kubernetes/Openshift environment.
+
+There has been some exploratory work for deploying infrastructure in Azure.
+
+Please reach out to the APS team to discuss your requirements if the helm chart is not sufficient.
 
 ```sh
 export IP="<ip specified in the sdxEndpoint above>"
@@ -108,40 +129,80 @@ export EDGE_ID="<name specified above>"
 export DOMAIN="${EDGE_ID}.servers.sdx"
 
 helm upgrade --install ${EDGE_ID} \
-  --set tls.client.bootstrap.token=$(cat token) \
-  --set tls.client.cn=${DOMAIN} \
-  --set tls.server.ip=${IP} \
+  --set bootstrap.tls.token=$(cat token) \
+  --set bootstrap.tls.cn=${DOMAIN} \
+  --set bootstrap.tls.ip=${IP} \
   --set route.host=${DOMAIN} \
-  oci://ghcr.io/bcgov/aps-devops/sdx-edge:0.1.0
+  oci://ghcr.io/bcgov/aps-devops/sdx-edge:0.2.0
 ```
 
-## Initialize default route policies
+## Create runtime group gateway
 
-You can now call the API to preview and then publish the default routing rules for
-the runtime group.
+As a System Owner, you perform this task. Once complete, you can set up the
+default routing policies for this runtime group.
 
-- **API** `PUT /organizations/{org}/pattern?action=apply&dryRun=true`
+=== "Restish CLI"
 
-Parameters:
+    Help information about the operation to assign  a runtime group:
 
-- `{org}=<your-organization>`
-- values for `action`: `preview` and `apply`
+    ```sh
+    restish sdx register-runtime-group-gateway
+    ```
 
-For `action=apply` you can specify `dryRun=true` if you want to see what changes
-will be applied without the changes actually being made.
+    Example:
 
-### `sdx-runtime-group.r1`
+    ```sh
+    restish sdx register-runtime-group-gateway \
+      ministry-of-citz newrg
+    ```
 
-```json
-{
-  "pattern": "sdx-runtime-group.r1",
-  "parameters": {
-    "runtime_group_name": "<runtime-group-name>"
-  }
-}
-```
+    An assigned Gateway ID will be returned. This Gateway can be used to configure
+    default routes and controls for this runtime group.
 
-## Verification
+## Apply default routes and controls
+
+=== "Restish CLI"
+
+    Help information about the operation to list available runtimes:
+
+    ```sh
+    restish sdx generate-config-from-pattern
+    ```
+
+    Example:
+
+    ```sh
+    restish sdx generate-config-from-pattern \
+      ministry-of-citz \
+      --action apply --dry-run=false \
+      'pattern:sdx-runtime-group.r1, parameters:{ runtime_group_name: "newrg" }'
+    ```
+
+=== "Reference"
+
+    You can now call the API to preview and then publish the default routing rules for
+    the runtime group.
+
+    - **API** `PUT /organizations/{org}/pattern?action=apply&dryRun=true`
+
+    Parameters:
+
+    - `{org}=<your-organization>`
+    - values for `action`: `preview` and `apply`
+
+    For `action=apply` you can specify `dryRun=true` if you want to see what changes
+    will be applied without the changes actually being made.
+
+    ```json
+    {
+      "pattern": "sdx-runtime-group.r1",
+      "parameters": {
+        "runtime_group_name": "<runtime-group-name>"
+      }
+    }
+    ```
+
+## Verification test
 
 Running the following should return 400 No required SSL certificate was sent.
 
@@ -158,25 +219,45 @@ curl -v --resolve internal.${DOMAIN}:8000:127.0.0.1 \
   http://internal.${DOMAIN}:8000/hello
 ```
 
-## Add public key to the registry
+## Add public key to registry
 
 The public key will be used for other runtime groups to verify the integrity
 of the request.
 
-Using the same pattern endpoint from above, you can use the `sdx-keys.r1` pattern
-to add the public key using the certificate from the runtime group.
+The helm deployment and bootstrap job will create the sdx-edge secret for the tls certificate
+pair. Save the `tls.crt` contents to a `tls.crt` file locally.
 
-### `sdx-keys.r1`
+=== "Restish CLI"
 
-```json
-{
-  "pattern": "sdx-keys.r1",
-  "parameters": {
-    "runtime_group_name": "<runtime-group-name>",
-    "certificate_pem": "<public-certificate-pem-format>"
-  }
-}
-```
+    Help information about the operation:
+
+    ```sh
+    restish sdx generate-config-from-pattern
+    ```
+
+    Example call:
+
+    ```sh
+    restish sdx generate-config-from-pattern \
+      ministry-of-citz \
+      --action apply --dry-run=false \
+      'pattern:sdx-keys.r1, parameters:{ certificate_pem[0]: @tls.crt, runtime_group_name: "newrg" }'
+    ```
+
+=== "Reference"
+
+    Using the same pattern endpoint from above, you can use the `sdx-keys.r1` pattern
+    to add the public key using the certificate from the runtime group.
+
+    ```json
+    {
+      "pattern": "sdx-keys.r1",
+      "parameters": {
+        "runtime_group_name": "<runtime-group-name>",
+        "certificate_pem": "<public-certificate-pem-format>"
+      }
+    }
+    ```
 
 ## Next steps
 

--- a/documentation/how-to/sdx-edge-servers.md
+++ b/documentation/how-to/sdx-edge-servers.md
@@ -31,6 +31,7 @@ Use cases for `client-hosted`:
 ## Prerequisites
 
 - [Install Restish CLI](/reference/restish-cli.md)
+- [Install Helm](https://helm.sh/docs/intro/install/) (if deploying the runtime group infrastructure)
 
 ## Register a new runtime group
 
@@ -105,7 +106,7 @@ This is performed by a System Owner to request a new cert signing token.
 
 === "Reference"
 
-    - **API** `PUT /organizations/{org}/runtime-groups/{name}/tokens`
+    - **API** `POST /organizations/{org}/runtime-groups/{name}/tokens`
 
     Parameters:
 
@@ -143,7 +144,7 @@ default routing policies for this runtime group.
 
 === "Restish CLI"
 
-    Help information about the operation to assign  a runtime group:
+    Help information about the operation to assign a runtime group:
 
     ```sh
     restish sdx register-runtime-group-gateway
@@ -156,14 +157,29 @@ default routing policies for this runtime group.
       ministry-of-citz newrg
     ```
 
-    An assigned Gateway ID will be returned. This Gateway can be used to configure
-    default routes and controls for this runtime group.
+=== "Reference"
+
+    - **API** `PUT /organizations/{org}/runtime-groups/{name}/gateway`
+
+    Parameters:
+
+    - `{org}=<your-organization>`
+    - `{name}=<your-runtime-group-name>`
+
+An assigned Gateway ID will be returned. This Gateway can be used to configure
+default routes and controls for this runtime group.
 
 ## Apply default routes and controls
 
+You can now call the API to preview and then publish Gateway configuration
+containing the default routing rules for the runtime group.
+
+For `action=apply` you can specify `dryRun=true` if you want to see what changes
+will be applied without the changes actually being made.
+
 === "Restish CLI"
 
-    Help information about the operation to list available runtimes:
+    Help information about the operation to generate and apply Gateway configuration:
 
     ```sh
     restish sdx generate-config-from-pattern
@@ -180,18 +196,12 @@ default routing policies for this runtime group.
 
 === "Reference"
 
-    You can now call the API to preview and then publish the default routing rules for
-    the runtime group.
-
     - **API** `PUT /organizations/{org}/pattern?action=apply&dryRun=true`
 
     Parameters:
 
     - `{org}=<your-organization>`
     - values for `action`: `preview` and `apply`
-
-    For `action=apply` you can specify `dryRun=true` if you want to see what changes
-    will be applied without the changes actually being made.
 
     ```json
     {

--- a/documentation/how-to/sdx-edge-servers.md
+++ b/documentation/how-to/sdx-edge-servers.md
@@ -26,7 +26,7 @@ Use cases for `client-hosted`:
 - Deploy the runtime group infrastructure
 - Apply default routes and controls
 - Verification test
-- Add public key to registry
+- Add public key to the registry
 
 ## Prerequisites
 
@@ -229,7 +229,7 @@ curl -v --resolve internal.${DOMAIN}:8000:127.0.0.1 \
   http://internal.${DOMAIN}:8000/hello
 ```
 
-## Add public key to registry
+## Add public key to the registry
 
 The public key will be used for other runtime groups to verify the integrity
 of the request.

--- a/documentation/how-to/sdx-org-onboarding.md
+++ b/documentation/how-to/sdx-org-onboarding.md
@@ -29,8 +29,6 @@ Available environments:
 
 This is performed by the SDX Operator to onboard a new Organization.
 
-=== "Restish CLI"
-
 === "Reference"
 
     - **API** `PUT /organizations/{org}`
@@ -79,4 +77,4 @@ Parameters: `{org}=ministry-of-food`
 
 ## Next steps
 
-- [Provision an edge server](/how-to/sdx-edge-servers.md)
+- [Install a Runtime Group](/how-to/sdx-edge-servers.md)

--- a/documentation/how-to/sdx-org-onboarding.md
+++ b/documentation/how-to/sdx-org-onboarding.md
@@ -19,12 +19,11 @@ Use cases:
 
 Available environments:
 
-| Environment | Links                                                                                                                                                                                                                                                           |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LAB`       | [API Console](https://api-gov-bc-ca-lab.dev.api.gov.bc.ca/ds/api/sdx/v1/console), [OpenAPI Specification](https://api-gov-bc-ca-lab.dev.api.gov.bc.ca/ds/api/sdx/v1/openapi.yaml), [Login](https://api-gov-bc-ca-lab.dev.api.gov.bc.ca/login?identity=provider) |
-| `DEV`       | [API Console](https://api-gov-bc-ca.dev.api.gov.bc.ca/ds/api/sdx/v1/console), [OpenAPI Specification](https://api-gov-bc-ca.dev.api.gov.bc.ca/ds/api/sdx/v1/openapi.yaml), [Login](https://api-gov-bc-ca.dev.api.gov.bc.ca/login?identity=provider)             |
-| `TEST`      | Coming soon                                                                                                                                                                                                                                                     |
-| `PROD`      | Coming soon                                                                                                                                                                                                                                                     |
+| Environment | Links                                                                                                                                                                                                                                               |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEV`       | [API Console](https://api-gov-bc-ca.dev.api.gov.bc.ca/ds/api/sdx/v1/console), [OpenAPI Specification](https://api-gov-bc-ca.dev.api.gov.bc.ca/ds/api/sdx/v1/openapi.yaml), [Login](https://api-gov-bc-ca.dev.api.gov.bc.ca/login?identity=provider) |
+| `TEST`      | Coming soon                                                                                                                                                                                                                                         |
+| `PROD`      | Coming soon                                                                                                                                                                                                                                         |
 
 ## Register new organization
 
@@ -77,3 +76,7 @@ Parameters: `{org}=ministry-of-food`
   ]
 }
 ```
+
+## Next steps
+
+- [Provision an edge server](/how-to/sdx-edge-servers.md)

--- a/documentation/how-to/sdx-org-signing.md
+++ b/documentation/how-to/sdx-org-signing.md
@@ -93,6 +93,24 @@ Once you receive back the certificate, save the certificate
 (and its intermediate CAs) in a `new.crt` file, and the root
 certificate for the CA in `root.crt`.
 
+Use one of the root certificates from below depending on your environment:
+
+**dev**:
+
+```text
+-----BEGIN CERTIFICATE-----
+MIIBozCCAUqgAwIBAgIRAOqrFxwuBQzATeE2ybv4ci8wCgYIKoZIzj0EAwIwMDEu
+MCwGA1UEAxMlQ1NCQyBTZWN1cmUgRGF0YSBFeGNoYW5nZSBERVYgUm9vdCBDQTAe
+Fw0yNjAzMjEyMDE2MDFaFw0zNjAzMTgyMDE2MDFaMDAxLjAsBgNVBAMTJUNTQkMg
+U2VjdXJlIERhdGEgRXhjaGFuZ2UgREVWIFJvb3QgQ0EwWTATBgcqhkjOPQIBBggq
+hkjOPQMBBwNCAASkZrREActpsjEdst6vKcQmxEeO6OuVnoBQ7luxWymcSosJJCHD
+WEV/2e9EyGPLHpw5RstPgx+Ha5D6+BcKGzjio0UwQzAOBgNVHQ8BAf8EBAMCAQYw
+EgYDVR0TAQH/BAgwBgEB/wIBAjAdBgNVHQ4EFgQUYb2Jz7MuAOKY8bu9NM6tjvS6
+xkYwCgYIKoZIzj0EAwIDRwAwRAIgTFXSb8bq5Z8P8oICO3BVHkHxCm0GRcqL10TL
+GtlsuWYCIBPfZrhbZX4oFhEk0sq7HXlBJuh6Zaa6dcsO3RIUt1Gm
+-----END CERTIFICATE-----
+```
+
 You will then be able to use this information to update the
 public key details with the new certificate in the JWKS registry.
 

--- a/documentation/how-to/sdx-org-signing.md
+++ b/documentation/how-to/sdx-org-signing.md
@@ -3,10 +3,17 @@ title: "Setup Organization Signing"
 ---
 
 Organization signing is used to cryptographically verify that messages were transmitted
-with permission between the involved systems.
+with permission between the involved systems using an authorized Runtime Group.
 
-Before systems can make connections, the organization must register signing keys
-with the Runtime Group that their systems are using to connect to SDX.
+!!! note "Setup is Optional"
+
+    There are various upgrades related to the connection that can be enabled.
+    Performing the counter-sign using the organization keys is one of these upgrades.
+    See [Connection Gateway Patterns](/how-to/sdx-upgrades.md) for more information.
+
+    If policy requires this to be enabled, then follow the steps to setup organization
+    signing. The organization must register signing keys
+    with the Runtime Group that their systems are using to connect to SDX.
 
 | Role               | Function                             |
 | ------------------ | ------------------------------------ |
@@ -16,7 +23,7 @@ Use cases:
 
 - Request a new signing key CSR
 - Get the CSR signed by an approved Certificate Authority
-- Register CA signed certificate
+- Add CA signed certificate to registry
 
 ## Prerequisites
 
@@ -80,14 +87,14 @@ SDX Operator provides a Certificate Authority (CA).
 
 Reach out to the APS team with your CSR to get it reviewed, approved and signed.
 
-## Register the CA signed certificate
+## Add CA signed certificate to registry
 
 Once you receive back the certificate, save the certificate
 (and its intermediate CAs) in a `new.crt` file, and the root
 certificate for the CA in `root.crt`.
 
 You will then be able to use this information to update the
-public key details with the new certificate.
+public key details with the new certificate in the JWKS registry.
 
 === "Restish CLI"
 

--- a/documentation/how-to/sdx-subsystems.md
+++ b/documentation/how-to/sdx-subsystems.md
@@ -218,3 +218,7 @@ policies for connecting to other systems on SDX.
 
     An assigned Gateway ID will be returned. This Gateway can be used to configure
     routes and controls for services it connects to.
+
+## Next steps
+
+- [Connecting a service](/how-to/sdx-connections.md)

--- a/documentation/how-to/sdx-subsystems.md
+++ b/documentation/how-to/sdx-subsystems.md
@@ -1,5 +1,5 @@
 ---
-title: "Managing systems and services"
+title: "Managing Systems and Services"
 ---
 
 ## Overview
@@ -221,4 +221,4 @@ policies for connecting to other systems on SDX.
 
 ## Next steps
 
-- [Connecting a service](/how-to/sdx-connections.md)
+- [Connecting a Service](/how-to/sdx-connections.md)

--- a/documentation/how-to/sdx-upgrades.md
+++ b/documentation/how-to/sdx-upgrades.md
@@ -1,0 +1,74 @@
+---
+title: "P2P Gateway Pattern Upgrades"
+---
+
+Gateway patterns for peer-to-peer will have different rules over time around how
+they should be configured. This page describes the rules for each policy release.
+
+As new feature like token exchange, dpop, and policy enforcement engine get added,
+there will be a new policy version describing what is required for a connection
+between systems.
+
+## Releases
+
+### SDX.R0.00
+
+#### sdx-p2p-consumer.r1
+
+- following parameters MUST be set: `conn_id`, `client_id`, `service_id`
+- following parameters MAY be set: `tls_verify`, `upgrades`, `rg_override`
+- `rg_override` can be `subsystem` (the RG that the client subsystem
+  is associated with) or `pzgw` (Privacy Zone Gateway)
+
+| Parameter     | Type               | Rule                          |
+| ------------- | ------------------ | ----------------------------- |
+| `conn_id`     | string             | required                      |
+| `client_id`   | string             | required                      |
+| `service_id`  | string             | required                      |
+| `rg_override` | `subsystem / pzgw` | optional, default `subsystem` |
+| `upgrades`    | object             | optional                      |
+
+**upgrades:**
+
+| Parameter         | Type     | Rule                |
+| ----------------- | -------- | ------------------- |
+| `dpop`            | object   | optional            |
+|                   |          |                     |
+| `sign`            | object   | optional            |
+|                   |          |                     |
+| `verify`          | object   | optional            |
+|                   |          |                     |
+| `counter_sign`    | object   | optional            |
+|                   |          |                     |
+| `token_exchange`  | object   | optional            |
+| `.client_id`      | string   | required            |
+| `.token_endpoint` | string   | required, any value |
+| `.scopes`         | string[] | optional            |
+| `.audience`       | string   | optional            |
+
+#### sdx-p2p-provider.r1
+
+- following parameters MUST be set: `conn_id`, `client_id`, `service_id`
+- following parameters MAY be set: `tls_verify`, `upgrades`, `rg_override`
+- `rg_override` can be `subsystem` (the RG that the client subsystem
+  is associated with) or `pzgw` (Privacy Zone Gateway)
+
+| Parameter     | Type               | Rule                          |
+| ------------- | ------------------ | ----------------------------- |
+| `conn_id`     | string             | required                      |
+| `client_id`   | string             | required                      |
+| `service_id`  | string             | required                      |
+| `rg_override` | `subsystem / pzgw` | optional, default `subsystem` |
+| `upgrades`    | object             | optional                      |
+
+**upgrades:**
+
+| Parameter      | Type   | Rule     |
+| -------------- | ------ | -------- |
+| `mtls_auth`    | object | optional |
+|                |        |          |
+| `mtls_acl`     | object | optional |
+|                |        |          |
+| `verify`       | object | optional |
+|                |        |          |
+| `counter_sign` | object | optional |

--- a/documentation/how-to/sdx-upgrades.md
+++ b/documentation/how-to/sdx-upgrades.md
@@ -1,24 +1,23 @@
 ---
-title: "P2P Gateway Pattern Upgrades"
+title: "Connection Gateway Patterns"
 ---
 
 Gateway patterns for peer-to-peer will have different rules over time around how
 they should be configured. This page describes the rules for each policy release.
 
-As new feature like token exchange, dpop, and policy enforcement engine get added,
-there will be a new policy version describing what is required for a connection
-between systems.
+## **SDX.R0.00**
 
-## Releases
+This policy makes all controls/upgrades optional - it only opens up the connection
+between the two subsystems. This will be used in development only. Test and
+production will require certain controls to be configured in a particular way.
 
-### SDX.R0.00
-
-#### sdx-p2p-consumer.r1
+### sdx-p2p-consumer.r1
 
 - following parameters MUST be set: `conn_id`, `client_id`, `service_id`
 - following parameters MAY be set: `tls_verify`, `upgrades`, `rg_override`
 - `rg_override` can be `subsystem` (the RG that the client subsystem
-  is associated with) or `pzgw` (Privacy Zone Gateway)
+  is associated with) or `pzgw` (A public-facing RG for handling token
+  requirements, such as token exchange and policy enforcement)
 
 | Parameter     | Type               | Rule                          |
 | ------------- | ------------------ | ----------------------------- |
@@ -30,45 +29,64 @@ between systems.
 
 **upgrades:**
 
-| Parameter         | Type     | Rule                |
-| ----------------- | -------- | ------------------- |
-| `dpop`            | object   | optional            |
-|                   |          |                     |
-| `sign`            | object   | optional            |
-|                   |          |                     |
-| `verify`          | object   | optional            |
-|                   |          |                     |
-| `counter_sign`    | object   | optional            |
-|                   |          |                     |
-| `token_exchange`  | object   | optional            |
-| `.client_id`      | string   | required            |
-| `.token_endpoint` | string   | required, any value |
-| `.scopes`         | string[] | optional            |
-| `.audience`       | string   | optional            |
+| Parameter                          | Type     | Rule                |
+| ---------------------------------- | -------- | ------------------- |
+| `sign`                             | object   | optional            |
+|                                    |          |                     |
+| `verify`                           | object   | optional            |
+|                                    |          |                     |
+| `counter_sign`                     | object   | optional            |
+|                                    |          |                     |
+| `dpop`                             | object   | optional            |
+|                                    |          |                     |
+| `token`                            | object   | optional            |
+| `.allowed_aud`                     | string   | required            |
+| `.allowed_iss`                     | string[] | required            |
+| `.scope`                           | string   | optional            |
+| `.consumer_match`                  | boolean  | optional            |
+| `.consumer_match_claim`            | string   | optional            |
+| `.consumer_match_claim_custom_id`  | boolean  | optional            |
+| `.consumer_match_ignore_not_found` | boolean  | optional            |
+|                                    |          |                     |
+| `token_exchange`                   | object   | optional            |
+| `.client_id`                       | string   | required            |
+| `.token_endpoint`                  | string   | required, any value |
+| `.scopes`                          | string[] | optional            |
+| `.audience`                        | string   | optional            |
 
-#### sdx-p2p-provider.r1
+### sdx-p2p-provider.r1
 
 - following parameters MUST be set: `conn_id`, `client_id`, `service_id`
 - following parameters MAY be set: `tls_verify`, `upgrades`, `rg_override`
 - `rg_override` can be `subsystem` (the RG that the client subsystem
   is associated with) or `pzgw` (Privacy Zone Gateway)
 
-| Parameter     | Type               | Rule                          |
-| ------------- | ------------------ | ----------------------------- |
-| `conn_id`     | string             | required                      |
-| `client_id`   | string             | required                      |
-| `service_id`  | string             | required                      |
-| `rg_override` | `subsystem / pzgw` | optional, default `subsystem` |
-| `upgrades`    | object             | optional                      |
+| Parameter    | Type   | Rule     |
+| ------------ | ------ | -------- |
+| `conn_id`    | string | required |
+| `client_id`  | string | required |
+| `service_id` | string | required |
+| `upgrades`   | object | optional |
 
 **upgrades:**
 
-| Parameter      | Type   | Rule     |
-| -------------- | ------ | -------- |
-| `mtls_auth`    | object | optional |
-|                |        |          |
-| `mtls_acl`     | object | optional |
-|                |        |          |
-| `verify`       | object | optional |
-|                |        |          |
-| `counter_sign` | object | optional |
+| Parameter                          | Type     | Rule     |
+| ---------------------------------- | -------- | -------- |
+| `mtls_auth`                        | object   | optional |
+|                                    |          |          |
+| `mtls_acl`                         | object   | optional |
+|                                    |          |          |
+| `sign`                             | object   | optional |
+|                                    |          |          |
+| `verify`                           | object   | optional |
+|                                    |          |          |
+| `counter_sign`                     | object   | optional |
+|                                    |          |          |
+| `token`                            | object   | optional |
+| `.allowed_aud`                     | string   | required |
+| `.allowed_iss`                     | string[] | required |
+| `.scope`                           | string   | optional |
+| `.consumer_match`                  | boolean  | optional |
+| `.consumer_match_claim`            | string   | optional |
+| `.consumer_match_claim_custom_id`  | boolean  | optional |
+| `.consumer_match_ignore_not_found` | boolean  | optional |

--- a/documentation/how-to/sdx-upgrades.md
+++ b/documentation/how-to/sdx-upgrades.md
@@ -11,35 +11,44 @@ This policy makes all controls/upgrades optional - it only opens up the connecti
 between the two subsystems. This will be used in development only. Test and
 production will require certain controls to be configured in a particular way.
 
-### sdx-p2p-consumer.r1
+### Connection Request
+
+- following parameters MUST by set: `clientId`, `serviceId`
+
+| Parameter    | Type    | Rule     |
+| ------------ | ------- | -------- |
+| `clientId`   | string  | required |
+| `serviceId`  | string  | required |
+| `isApproved` | boolean | required |
+
+`isApproved` is set by the service system owner.
+
+### Pattern sdx-p2p-consumer.r1
 
 - following parameters MUST be set: `conn_id`, `client_id`, `service_id`
-- following parameters MAY be set: `tls_verify`, `upgrades`, `rg_override`
-- `rg_override` can be `subsystem` (the RG that the client subsystem
-  is associated with) or `pzgw` (A public-facing RG for handling token
-  requirements, such as token exchange and policy enforcement)
+- following parameters MAY be set: `tls_verify`, `upgrades`
 
-| Parameter     | Type               | Rule                          |
-| ------------- | ------------------ | ----------------------------- |
-| `conn_id`     | string             | required                      |
-| `client_id`   | string             | required                      |
-| `service_id`  | string             | required                      |
-| `rg_override` | `subsystem / pzgw` | optional, default `subsystem` |
-| `upgrades`    | object             | optional                      |
+| Parameter    | Type    | Rule                     |
+| ------------ | ------- | ------------------------ |
+| `conn_id`    | string  | required                 |
+| `client_id`  | string  | required                 |
+| `service_id` | string  | required                 |
+| `tls_verify` | boolean | optional, default `true` |
+| `upgrades`   | object  | optional                 |
 
 **upgrades:**
 
 | Parameter                          | Type     | Rule                |
 | ---------------------------------- | -------- | ------------------- |
-| `sign`                             | object   | optional            |
+| **sign**                           | object   | optional            |
 |                                    |          |                     |
-| `verify`                           | object   | optional            |
+| **verify**                         | object   | optional            |
 |                                    |          |                     |
-| `counter_sign`                     | object   | optional            |
+| **counter_sign**                   | object   | optional            |
 |                                    |          |                     |
-| `dpop`                             | object   | optional            |
+| **dpop**                           | object   | optional            |
 |                                    |          |                     |
-| `token`                            | object   | optional            |
+| **token**                          | object   | optional            |
 | `.allowed_aud`                     | string   | required            |
 | `.allowed_iss`                     | string[] | required            |
 | `.scope`                           | string   | optional            |
@@ -48,18 +57,16 @@ production will require certain controls to be configured in a particular way.
 | `.consumer_match_claim_custom_id`  | boolean  | optional            |
 | `.consumer_match_ignore_not_found` | boolean  | optional            |
 |                                    |          |                     |
-| `token_exchange`                   | object   | optional            |
+| **token_exchange**                 | object   | optional            |
 | `.client_id`                       | string   | required            |
 | `.token_endpoint`                  | string   | required, any value |
 | `.scopes`                          | string[] | optional            |
 | `.audience`                        | string   | optional            |
 
-### sdx-p2p-provider.r1
+### Pattern sdx-p2p-provider.r1
 
 - following parameters MUST be set: `conn_id`, `client_id`, `service_id`
-- following parameters MAY be set: `tls_verify`, `upgrades`, `rg_override`
-- `rg_override` can be `subsystem` (the RG that the client subsystem
-  is associated with) or `pzgw` (Privacy Zone Gateway)
+- following parameter MAY be set: `upgrades`
 
 | Parameter    | Type   | Rule     |
 | ------------ | ------ | -------- |
@@ -72,17 +79,17 @@ production will require certain controls to be configured in a particular way.
 
 | Parameter                          | Type     | Rule     |
 | ---------------------------------- | -------- | -------- |
-| `mtls_auth`                        | object   | optional |
+| **mtls_auth**                      | object   | optional |
 |                                    |          |          |
-| `mtls_acl`                         | object   | optional |
+| **mtls_acl**                       | object   | optional |
 |                                    |          |          |
-| `sign`                             | object   | optional |
+| **sign**                           | object   | optional |
 |                                    |          |          |
-| `verify`                           | object   | optional |
+| **verify**                         | object   | optional |
 |                                    |          |          |
-| `counter_sign`                     | object   | optional |
+| **counter_sign**                   | object   | optional |
 |                                    |          |          |
-| `token`                            | object   | optional |
+| **token**                          | object   | optional |
 | `.allowed_aud`                     | string   | required |
 | `.allowed_iss`                     | string[] | required |
 | `.scope`                           | string   | optional |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,9 +43,10 @@ nav:
       - Secure Data Exchange:
           - "how-to/sdx-org-onboarding.md"
           - "how-to/sdx-edge-servers.md"
-          - "how-to/sdx-subsystems.md"
           - "how-to/sdx-org-signing.md"
+          - "how-to/sdx-subsystems.md"
           - "how-to/sdx-connections.md"
+          - "how-to/sdx-upgrades.md"
   - Concepts:
       - "concepts/api-directory.md"
       - "concepts/services.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,8 @@ nav:
           - "how-to/sdx-subsystems.md"
           - "how-to/sdx-connections.md"
           - "how-to/sdx-upgrades.md"
+          - "how-to/sdx-ape-event-mgmt.md"
+          - "how-to/sdx-ape-policy-mgmt.md"
   - Concepts:
       - "concepts/api-directory.md"
       - "concepts/services.md"


### PR DESCRIPTION
## PR Summary

  **Nav & TOC**
  - `mkdocs.yml` — Reorders SDX how-to pages and adds three new entries to the nav: `sdx-upgrades`,
  `sdx-ape-event-mgmt`, and `sdx-ape-policy-mgmt`.
  - `documentation/concepts/secure-data-exchange.md` — Updates the how-to link list to match the new nav: renames
  the edge-server link to "Install a runtime group", drops the standalone org-signing link, and adds the two new
  (preview) Event Mgmt and Policy Mgmt links.

  **New how-to pages**
  - `documentation/how-to/sdx-upgrades.md` (new) — Central reference for Connection Gateway Patterns, documenting
  the rules and allowed parameters/upgrades (sign, verify, counter_sign, dpop, etc.) for `sdx-p2p-consumer.r1` and
   `sdx-p2p-provider.r1` under policy release `SDX.R0.00`.
  - `documentation/how-to/sdx-ape-event-mgmt.md` (new) — Preview-only guide for publishing an AsyncAPI service, 
  configuring publisher endpoints, connecting consumers, and setting up webhooks.
  - `documentation/how-to/sdx-ape-policy-mgmt.md` (new) — Preview-only guide for registering OPA/CEDAR policies, 
  upgrading a connection with a PEP, and registering a data source.

  **Existing how-to pages**
  - `documentation/how-to/sdx-edge-servers.md` — Major rewrite: retitled "Install a Runtime Group", clarifies 
  `client-hosted` vs `community-hosted` options, adds Restish CLI examples for every step, updates the helm chart 
  values (`bootstrap.tls.*`, chart version `0.2.0`), and adds new "Create runtime group gateway" and "Verification
   test" sections plus a next-steps link.
  - `documentation/how-to/sdx-org-signing.md` — Reframes org signing as an optional upgrade (with a callout 
  linking to `sdx-upgrades.md`), and renames the final step to "Add CA signed certificate to registry" with JWKS 
  wording.
  - `documentation/how-to/sdx-org-onboarding.md` — Drops the `LAB` environment row and the empty "Restish CLI" 
  tab, and adds a next-steps link to the runtime group guide.
  - `documentation/how-to/sdx-subsystems.md` — Title-cases the page title and adds a next-steps link to 
  "Connecting a Service".
  - `documentation/how-to/sdx-connections.md` — Removes the inline upgrade JSON blocks for both p2p patterns and 
  replaces them with links to the new `sdx-upgrades.md` reference; trims a now-empty `sign` upgrade from the 
  example payload.