### PR TITLE
Feature/aps 4776 m0 carryover

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,4 +10,4 @@ metadata:
 spec:
   type: documentation
   lifecycle: production
-  owner: "bcgov/databc-aps"
+  owner: group:default/databc-aps

--- a/documentation/concepts/secure-data-exchange.md
+++ b/documentation/concepts/secure-data-exchange.md
@@ -22,6 +22,23 @@ The Edge Server is a forward proxy for the service consumer (IS client) and a re
 
 Edge Servers sit in an organization's DMZ, where they are able to communicate with other Edge Servers in a secure and auditable way.
 
+### The public consumer host (PZGW)
+
+`pzgw` is the shared, community-hosted runtime group that acts as the public
+consumer entry point for member organizations that do not run their own
+Internet-routable edge. It is not a general-purpose provider runtime: a
+consumer application reaches SDX through PZGW's `consumerEndpoint`, PZGW then
+forwards the request edge-to-edge to the **provider's own runtime group**
+(over mTLS, using that runtime's `sdxEndpoint`), and the provider edge
+forwards it to the private provider `upstreamUrl`.
+
+Because PZGW is the only runtime with a widely recognizable public
+(`*.api.gov.bc.ca`) hostname, it is easy to mistake it for the provider
+runtime in a connection. It is not: the provider must still register and
+host its own runtime group (`client-hosted` or another `community-hosted`
+runtime group), and that runtime — not PZGW — must appear in the
+provider's organization `hostedOrganizations`.
+
 ## Next steps
 
 If you would like to dive deeper or start implementing services on SDX, check out the

--- a/documentation/how-to/sdx-connection-patterns.md
+++ b/documentation/how-to/sdx-connection-patterns.md
@@ -5,6 +5,21 @@ title: "Connection Gateway Patterns"
 Gateway patterns for peer-to-peer will have different rules over time around how
 they should be configured. This page describes all the parameters that are available.
 
+!!! note "These patterns are not invoked directly"
+    `sdx-p2p-consumer.r1`, `sdx-p2p-consumer-access.r1`, `sdx-p2p-provider.r1`,
+    and their `upgrades` are **connection resources**, not gateway patterns
+    invoked through the public `/patterns` endpoint or
+    `provision-config-from-pattern`. You configure them by setting
+    `clientResources.gatewayPatterns` (consumer side) and
+    `serviceResources.gatewayPatterns` (provider side) on a connection via
+    `upsert-connection`, as shown in
+    [Manage Connections](/how-to/sdx-connections.md). The provisioner
+    evaluates them automatically whenever the connection's `isActive` state
+    changes — there is no separate preview/publish/delete step for these
+    patterns, and deleting a peer-to-peer configuration is done by setting
+    `isActive: false` on the connection rather than by deleting the pattern
+    directly.
+
 ## Connection Request
 
 - following parameters MUST by set: `clientId`, `serviceId`

--- a/documentation/how-to/sdx-connections.md
+++ b/documentation/how-to/sdx-connections.md
@@ -33,6 +33,14 @@ Use cases:
 
 ## Request access (as consumer)
 
+`policyVersion` selects the connection policy that governs how the
+connection is provisioned:
+
+| Policy        | Description                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------ |
+| `SDX.R0.00`   | Simple point-to-point connection policy. Requires a `requesterDetails` object (see below).       |
+| `SDX.R1.00`   | Adds integration/token-exchange support; requires additional requester and gateway resources and is not a drop-in default. |
+
 === "Restish CLI"
 
     Help information about the operation:
@@ -48,8 +56,20 @@ Use cases:
       my-org \
       clientId: MIN.MYORG.MY-NEW-SUBSYSTEM, \
       serviceId: LAB.MIN.MYORG.EFV-ICBC.v0, \
-      policyVersion: SDX.R0.00
+      policyVersion: SDX.R0.00, \
+      "requesterDetails: { requester: { name: 'Your Name' } }"
     ```
+
+    Under `SDX.R0.00`, `requesterDetails` must be supplied together with
+    `policyVersion` on this initial request — when both are present, the
+    controller replaces `requesterDetails.requester` with the authenticated
+    caller's name and email. Omitting `requesterDetails` leaves an invalid
+    empty default in place that will pass creation but fail activation.
+    `requesterDetails` can only be set on creation; it cannot be repaired
+    afterwards through `upsert-connection` (that field is reserved for the
+    provisioner on update) — if activation fails for a missing requester
+    record, deactivate and delete the connection, then recreate it with
+    `policyVersion` and `requesterDetails` included together.
 
 ## Review connection access requests
 
@@ -168,6 +188,26 @@ go to [Connection Gateway Patterns](/how-to/sdx-connection-patterns.md).
 
 For details on configuring the `sdx-p2p-provider.r1` pattern,
 go to [Connection Gateway Patterns](/how-to/sdx-connection-patterns.md).
+
+!!! note "Associating an OAuth integration client with a connection"
+    `requesterDetails.client.clientId` (used above for
+    `sdx-p2p-consumer-access.r1`/ACL and, when configured, `consumerMatch`)
+    is provisioner-managed. It cannot be written directly through the SDX
+    management API — attempting a direct `upsert-connection` update of
+    `requesterDetails` returns `HTTP 400`. Registering an
+    `integrationClientId` on the consumer subsystem (see
+    [Register an SDX Subsystem](/how-to/sdx-subsystems.md)) is only the
+    first half of the relationship: the field is populated by calling the
+    supported `POST /v1/integrations/{clientId}/access-requests` operation
+    on the SDX Partner Authorization Services API, which validates the
+    requested scopes against the registered OAD and writes the requester
+    metadata with trusted provisioner credentials. That API uses a separate
+    base URL and bearer-token audience from the main SDX API — consult the
+    APS team for the current Restish/API configuration for it. Before
+    enabling strict `consumerMatch`, verify that the connection contains the
+    integration client and that the Kong consumer created by
+    `sdx-p2p-consumer-access.r1` exists, since enabling `consumerMatch`
+    ahead of a matching consumer blocks legitimate traffic.
 
 ## Delete a connection request
 

--- a/documentation/how-to/sdx-connections.md
+++ b/documentation/how-to/sdx-connections.md
@@ -167,7 +167,7 @@ go to [Connection Gateway Patterns](/how-to/sdx-connection-patterns.md).
     ```
 
 For details on configuring the `sdx-p2p-provider.r1` pattern,
-go to [Connection Gateway Patterns](/how-to/sdx-upgrades.md).
+go to [Connection Gateway Patterns](/how-to/sdx-connection-patterns.md).
 
 ## Delete a connection request
 

--- a/documentation/how-to/sdx-edge-servers.md
+++ b/documentation/how-to/sdx-edge-servers.md
@@ -224,7 +224,7 @@ Actions available:
 
     ```sh
     restish sdx provision-config-from-pattern \
-      my-org sdx-runtime-group.v1 \
+      my-org sdx-runtime-group.r1 \
       --action apply \
       'parameters:{ runtimeGroupName: newrg, environment: lab }'
     ```

--- a/documentation/how-to/sdx-edge-servers.md
+++ b/documentation/how-to/sdx-edge-servers.md
@@ -168,12 +168,13 @@ This is performed by a System Owner to request a new cert signing token.
 
 === "Reference"
 
-    - **API** `POST /organizations/{org}/runtime-groups/{name}/tokens`
+    - **API** `POST /organizations/{org}/runtime-groups/{name}/environments/{environment}/tokens`
 
     Parameters:
 
     - `{org}=<your-organization>`
     - `{name}=<your-runtime-group-name>`
+    - `{environment}=<target-environment>`
 
 It will return a token which can be extracted and stored in a local file
 for the next step.

--- a/documentation/how-to/sdx-edge-servers.md
+++ b/documentation/how-to/sdx-edge-servers.md
@@ -89,6 +89,17 @@ will be used to route traffic to this runtime group.
 As a System Owner, you perform this task. Once complete, you can set up the
 default routing policies for this runtime group.
 
+!!! warning "Registration is not a safe retry"
+    `register-runtime-group-gateway` is create-only. If the runtime group's
+    namespace was already partially registered (for example after an earlier
+    failed or interrupted attempt), rerunning registration for the same name
+    fails rather than repairing the existing namespace, and manually deleting
+    the namespace can leave retained Kong catalog services/routes with no
+    corresponding live data-plane configuration. There is currently no
+    documented preflight or reconcile command for this state — verify with
+    the APS team before deleting an existing runtime namespace to retry
+    registration.
+
 === "Restish CLI"
 
     Help information about the operation to assign a runtime group:
@@ -115,6 +126,19 @@ default routing policies for this runtime group.
 
 An assigned Gateway ID will be returned. This Gateway can be used to configure
 default routes and controls for this runtime group.
+
+!!! note "Granting namespace access to additional users"
+    Registration grants SDX namespace scopes only to the caller who created
+    the runtime group's gateway. There is no Restish or other APS/SDX REST
+    operation for granting or repairing another user's scopes on an existing
+    namespace. Additional users must be granted access through the API
+    Services Portal's **Administration Access** page (GraphQL API), which
+    itself requires the requesting user to hold `Namespace.Manage` on that
+    namespace. Do not attempt to grant access by creating an ordinary
+    Keycloak authorization permission directly — the platform expects a
+    resource-owner-managed UMA permission ticket, and the two are not
+    interchangeable. A namespace with no `Namespace.Manage` holder currently
+    has no self-service recovery path; contact the APS team.
 
 ## Deploy runtime group infrastructure
 
@@ -205,6 +229,30 @@ Actions available:
       'parameters:{ runtimeGroupName: newrg, environment: lab }'
     ```
 
+!!! note "Required authorization scope"
+    The generated help for `provision-config-from-pattern` lists
+    `System.Manage` as the required scope. The effective requirement is
+    actually `GatewayPattern.Publish`, resolved against the runtime's
+    namespace (for example `<namespace>:GatewayPattern.Publish`), and it is
+    granted automatically to the runtime's registering System Owner.
+    Authorization happens in two stages: `GatewayPattern.Publish` gates the
+    `preview`/`diff`/`apply`/`delete` endpoint itself for the human caller,
+    and a separate `GatewayConfig.Publish` scope, held by the internal
+    `sdx-provisioner` client rather than the caller's own token, gates the
+    downstream GWA namespace publish that `diff` and `apply` trigger.
+    `preview` returns generated configuration before that downstream request
+    and therefore only needs the outer `GatewayPattern.Publish` scope.
+
+!!! note "Reading `diff` results"
+    `diff` is a dry run, but its response reuses mutation-sounding fields —
+    a top-level `applied` count and a per-provider `status: applied` — even
+    when nothing was changed. Those fields describe successful **processing**
+    of the dry run, not the number of gateway changes committed. Do not treat
+    a `diff` response as evidence that Kong configuration changed; check the
+    nested `details.message` (for example `Dry-run. No changes applied.`) and
+    the Created/Updated/Deleted summary for the actual proposed changes, and
+    use `apply` to commit them.
+
 ### Verification test
 
 Running the following should return `400 No required SSL certificate was sent`.
@@ -221,6 +269,15 @@ runtime group Kong pod and running:
 curl -v --resolve internal.${DOMAIN}:8000:127.0.0.1 \
   http://internal.${DOMAIN}:8000/hello
 ```
+
+!!! note "Peer TLS trust"
+    These checks verify the runtime group's own edge, but do not verify
+    trust between peer runtime groups. Before relying on an active
+    peer-to-peer connection, confirm that the calling edge's Kong trusts the
+    peer edge's issuing CA (Kong returns `HTTP 502` with an upstream TLS
+    verification failure otherwise). Also note that the endpoint host
+    displayed by the portal may be normalized by GWA to the namespace's
+    permitted environment domain rather than shown verbatim.
 
 ### Add public key to the registry
 
@@ -258,10 +315,25 @@ pair. Save the `tls.crt` contents to a `tls.crt` file locally.
       "parameters": {
         "runtimeGroupName": "<runtime-group-name>",
         "environment": "lab|dev|test|prod",
-        "certificatePem": "<public-certificate-pem-format>"
+        "certificatePem": ["<public-certificate-pem-format>"]
       }
     }
     ```
+
+    `certificatePem` is an array; only the public certificate is supplied
+    here, and the private key must remain mounted in the runtime group's
+    edge. `organization` is derived from the `{org}` path parameter and does
+    not need to be supplied in the body.
+
+!!! warning "Prerequisite for signed connections"
+    Registering the runtime group's public key with `sdx-keys.r1` is a
+    mandatory prerequisite before enabling the `sign` upgrade on a consumer
+    connection or the `verify` upgrade on a provider connection (see
+    [Manage Connections](/how-to/sdx-connections.md)). The `trust-sign`
+    plugin embeds the runtime's JWKS URI in the signature but does not create
+    or publish the key set itself — until `sdx-keys.r1` has been applied, the
+    JWKS URL will return `404 Key set not found` and traffic relying on
+    verification will fail.
 
 ## Decommission Runtime Group
 

--- a/documentation/how-to/sdx-org-onboarding.md
+++ b/documentation/how-to/sdx-org-onboarding.md
@@ -32,7 +32,7 @@ This is performed by the SDX Operator to onboard a new Organization.
 
 === "Restish CLI"
 
-    Help information about the operation to list available runtimes:
+    Help information about the organization creation/update operation:
 
     ```sh
     restish aps put-organization
@@ -70,24 +70,39 @@ This is performed by the SDX Operator to onboard a new Organization.
       "extSource": "custom",
       "extRecordHash": "0000",
       "tags": [
-        { "member_class": "MIN", "member_id": "FOOD" }
+        "member_class:MIN",
+        "member_id:FOOD"
       ],
       "publicBodyId": null,
       "orgUnits": []
     }
     ```
 
+    `tags` is `array<string>`. An array containing an object is rejected by
+    the live request schema.
+
 ## System Owner role assignment
 
 This is performed by the Organization Admin to assign system owners access to manage
 their systems and services.
 
-The `System Owner` is able to register new subsystems and services
-and browse the service catalog.
+The organization-scoped role that grants this access is `system-admin`, which
+carries `System.Manage` for the organization. This is distinct from any
+system-level roles and from `organization-admin`, which carries
+`GroupAccess.Manage`, `Namespace.Assign`, and `Dataset.Manage` instead.
+
+!!! warning
+    Some existing organizations were provisioned before this role was
+    introduced and still use a `system-owner` group instead. `system-owner` is
+    not a currently supported role for newly onboarded organizations; using it
+    returns `204 No Content` but does not create any organization-level group
+    or permission, so the member is granted no access. Use `system-admin` for
+    new organizations, and verify the resulting permission with a fresh token
+    after assignment.
 
 === "Restish CLI"
 
-    Help information about the operation to list available runtimes:
+    Help information about the organization role membership synchronization operation:
 
     ```sh
     restish aps put-organization-access
@@ -105,7 +120,7 @@ and browse the service catalog.
           "member": {
             "email": "aidan.cope@gov.bc.ca"
           },
-          "roles": ["system-owner"]
+          "roles": ["system-admin"]
         }
       ]
     }
@@ -128,7 +143,7 @@ and browse the service catalog.
           "member": {
             "email": "janis@testmail.com"
           },
-          "roles": ["system-owner"]
+          "roles": ["system-admin"]
         }
       ]
     }

--- a/documentation/how-to/sdx-org-onboarding.md
+++ b/documentation/how-to/sdx-org-onboarding.md
@@ -16,6 +16,7 @@ Use cases:
 
 - Register new organization
 - System Owner role assignment
+- List organizations
 - Assign gateway for organization
 
 Available environments:
@@ -148,6 +149,61 @@ system-level roles and from `organization-admin`, which carries
       ]
     }
     ```
+
+## List organizations
+
+Retrieve the list of organizations available in the SDX catalog, optionally
+including each organization's RBAC role membership.
+
+=== "Restish CLI"
+
+    ```sh
+    restish sdx organization-list
+    ```
+
+    Include role membership:
+
+    ```sh
+    restish sdx organization-list --include-access
+    ```
+
+=== "Reference"
+
+    - **API** `GET /catalog/organizations`
+
+    Query parameters:
+
+    - `includeAccess` (optional, boolean, default `false`) - when `true`,
+      each organization entry includes an `access` array of its RBAC role
+      members (`organization-admin`, `system-admin`).
+
+    ```json title="Response Body (includeAccess=true)"
+    [
+      {
+        "name": "ministry-of-food",
+        "title": "Ministry of Food",
+        "description": "It is a ministry concerned with food",
+        "member": {
+          "memberClass": "MIN",
+          "memberId": "FOOD"
+        },
+        "access": [
+          {
+            "member": { "email": "janis@testmail.com" },
+            "roles": ["system-admin"]
+          }
+        ]
+      }
+    ]
+    ```
+
+!!! note "`includeAccess` does not require authentication"
+    `organization-list` has always been callable without a bearer token, and
+    `includeAccess` does not change that: role membership is resolved using
+    the platform's own Keycloak service credentials, not the caller's - so
+    passing `includeAccess=true` returns every organization's role members
+    to anonymous callers, the same way the base listing already returns
+    every organization's name/title/member details to anonymous callers.
 
 ## Assign gateway for organization
 

--- a/documentation/how-to/sdx-org-signing.md
+++ b/documentation/how-to/sdx-org-signing.md
@@ -9,7 +9,7 @@ with permission between the involved systems using an authorized Runtime Group.
 
     There are various upgrades related to the connection that can be enabled.
     Performing the counter-sign using the organization keys is one of these upgrades.
-    See [Connection Gateway Patterns](/how-to/sdx-upgrades.md) for more information.
+    See [Connection Gateway Patterns](/how-to/sdx-connection-patterns.md) for more information.
 
     If policy requires this to be enabled, then follow the steps to setup organization
     signing. The organization must register signing keys

--- a/documentation/how-to/sdx-services.md
+++ b/documentation/how-to/sdx-services.md
@@ -46,6 +46,43 @@ Use cases:
       < openapi.yaml
     ```
 
+!!! note "OAS security scopes are not automatically enforced"
+    Distinct OpenAPI `security` scopes declared per-operation (read, create,
+    update, delete, etc.) are **not** automatically converted into
+    route-level runtime authorization. Registering an OAS that declares
+    scopes does not by itself restrict which operations a caller with a
+    valid token can reach. Runtime access control must be configured
+    explicitly through connection `upgrades` — see the `token`,
+    `consumerMatch`, and `tokenExchange` options in
+    [Connection Gateway Patterns](/how-to/sdx-connection-patterns.md) and the
+    [JWT Keycloak plugin](/reference/plugins/jwt-keycloak.md) — and, as
+    deployed today, the JWT guard verifies the token's signature, issuer,
+    expiry, and `sub`, but does not itself verify `scope`, audience, or
+    authorized party. Treat declared OAS scopes as descriptive metadata
+    until per-operation enforcement is explicitly configured.
+
+### Troubleshooting service registration
+
+A `create-oas-service` request can return `HTTP 503`,
+`validation_service_unavailable`, `OAS validation service unavailable` for
+two different reasons that look identical to the caller:
+
+- the validation service is genuinely unreachable or timed out, or
+- the validation service is reachable and responded, but its internal rules
+  engine failed to process the document (for example, a Spectral rule
+  throwing on a legitimate `null` value in the document).
+
+Both cases currently surface as the same `503`. If you hit this error:
+
+- retry once to rule out a transient network/timeout issue;
+- if it persists, check whether the validator's `/versions` endpoint is
+  reachable and returning `200` — if it is, the failure is more likely in
+  the rules engine than in service availability;
+- if the failure appears tied to a specific document construct (for
+  example, a nullable field with an explicit `null` example value), report
+  it to the APS team with the offending OAS fragment rather than continuing
+  to retry.
+
 ## View API service catalog
 
 === "Restish CLI"
@@ -61,6 +98,35 @@ Use cases:
     ```sh
     restish sdx list-service-catalog | jq '.[] | .name+": "+.title'
     ```
+
+### Retrieve a service's OpenAPI Description (OAD)
+
+The registered OAD for a service can be retrieved two ways:
+
+- publicly, with no credentials required:
+
+  ```text
+  GET /ds/api/sdx/v1/catalog/services/{serviceId}/oas-spec
+  ```
+
+- organization-scoped, requiring `System.Manage`, via the
+  `get-organization-service-spec` Restish operation.
+
+Neither operation returns the fully SDX-transformed publication artifact
+described by the SDX API Standard. The stored document is
+validation-enriched only — registration adds `x-csbc-api-standard` and
+`x-csbc-api-standard-ruleset` under `info`, recording the validation
+service's version and ruleset — but the `servers` section, OAuth endpoints,
+and provider `info.contact` are otherwise returned as uploaded, and no SDX
+`externalDocs` is added. Do not assume the retrieved document's `servers` or
+OAuth URLs are environment-correct without further transformation.
+
+`x-csbc-api-standard` here records the validation service version, not a
+provider-declared API standard release name; treat its meaning as
+implementation-specific until this is reconciled with the SDX API Standard.
+
+An interactive Swagger UI is not currently provided through SDX for a
+registered service; only the OAD retrieval operations above are available.
 
 ## Service management
 

--- a/documentation/how-to/sdx-subsystems.md
+++ b/documentation/how-to/sdx-subsystems.md
@@ -17,6 +17,7 @@ Use cases:
 - Register a subsystem
 - Assign your subsystem to a runtime group
 - Subsystem management
+  - Administer subsystem RBAC
   - Delete a subsystem
 
 ## Prerequisites
@@ -148,6 +149,116 @@ policies for connecting to other systems on SDX.
     the APS team for recovery rather than deleting and recreating.
 
 ## Subsystem management
+
+### Administer subsystem RBAC
+
+A subsystem's creator is granted all three roles automatically when
+[assigning the subsystem to a runtime group](#assign-your-subsystem-to-a-runtime-group).
+Use this operation afterward to add, change, or remove role membership -
+for example when a colleague joins the team or the creator leaves the
+organization.
+
+The supported roles are:
+
+| Role              | Function                                    |
+| ----------------- | -------------------------------------------- |
+| `system-owner`    | Overall accountable owner for the subsystem |
+| `tech-lead`       | Technical point of contact for the subsystem |
+| `access-manager`  | Manages who has access to the subsystem     |
+
+!!! warning "Updating access replaces the full member list"
+    `put-subsystem-access` is a full sync, not an incremental grant: any
+    member/role combination not included in the request body is **revoked**.
+    To add one person without affecting anyone else, first call
+    `get-subsystem-access` and include its existing members in your update
+    alongside the new one.
+
+=== "Restish CLI"
+
+    Help information about the operation to get current access:
+
+    ```sh
+    restish sdx get-subsystem-access
+    ```
+
+    Example:
+
+    ```sh
+    restish sdx get-subsystem-access \
+      my-org SUBSYSTEM-NAME
+    ```
+
+    Help information about the operation to update access:
+
+    ```sh
+    restish sdx put-subsystem-access
+    ```
+
+    Example - grants Janis all three roles and Mark `access-manager` only
+    (and revokes any other role membership not listed here):
+
+    ```sh
+    echo '
+    {
+      "members": [
+        {
+          "member": { "email": "janis@testmail.com" },
+          "roles": ["system-owner", "tech-lead", "access-manager"]
+        },
+        {
+          "member": { "email": "mark@gmail.com" },
+          "roles": ["access-manager"]
+        }
+      ]
+    }
+    ' | restish sdx put-subsystem-access my-org SUBSYSTEM-NAME
+    ```
+
+    Confirm the change:
+
+    ```sh
+    restish sdx get-subsystem-access \
+      my-org SUBSYSTEM-NAME
+    ```
+
+=== "Reference"
+
+    - **API** `GET /organizations/{org}/subsystems/{name}/access`
+
+    Parameters:
+
+    - `{org}=<your-organization>`
+    - `{name}=<subsystem-name>`
+
+    ```json title="Response Body"
+    [
+      {
+        "member": { "email": "janis@testmail.com" },
+        "roles": ["system-owner", "tech-lead", "access-manager"]
+      }
+    ]
+    ```
+
+    - **API** `PUT /organizations/{org}/subsystems/{name}/access`
+
+    Parameters:
+
+    - `{org}=<your-organization>`
+    - `{name}=<subsystem-name>`
+
+    ```json title="Request Body"
+    {
+      "members": [
+        {
+          "member": { "email": "<user-email>" },
+          "roles": ["system-owner", "tech-lead", "access-manager"]
+        }
+      ]
+    }
+    ```
+
+    Submitting a role name other than `system-owner`, `tech-lead`, or
+    `access-manager` returns a `4xx` naming the unsupported value.
 
 ### Delete a subsystem
 

--- a/documentation/how-to/sdx-subsystems.md
+++ b/documentation/how-to/sdx-subsystems.md
@@ -124,6 +124,29 @@ policies for connecting to other systems on SDX.
     An assigned Gateway ID will be returned. This Gateway can be used to configure
     routes and controls for services it connects to.
 
+!!! warning "Confirm the runtime currently hosts your organization"
+    Registration currently succeeds with `HTTP 200` even if the chosen
+    runtime group's `hostedOrganizations` no longer includes your
+    organization — for example after a runtime's hosting was changed after
+    you queried `list-runtime-groups`. The resulting gateway is created but
+    is missing the runtime's host domain, which will cause confusing
+    downstream failures when publishing services or provider patterns.
+    After registering, call `get-subsystem-client` and confirm the runtime
+    group actually appears in the returned `runtimeGroups` before
+    proceeding.
+
+!!! warning "Registration is create-only"
+    `register-subsystem-gateway` cannot be used to repair or reconcile an
+    already-registered subsystem namespace — repeating it against an
+    existing namespace returns `HTTP 422 Namespace already exists`, even
+    after the underlying problem (such as the missing hosted-organization
+    relation above) has been corrected. Deleting the gateway to retry is not
+    a safe workaround for a deterministic SDX gateway ID: it removes the
+    resource set and marks the Keycloak namespace group `decommissioned`
+    while the subsystem continues to reference the same gateway ID, and the
+    namespace name will still be rejected as existing on a retry. Contact
+    the APS team for recovery rather than deleting and recreating.
+
 ## Subsystem management
 
 ### Delete a subsystem

--- a/documentation/reference/restish-cli.md
+++ b/documentation/reference/restish-cli.md
@@ -87,9 +87,9 @@ restish api edit
             "auth": {
               "name": "oauth-authorization-code",
               "params": {
-                "audience": "sdx-bruno-client",
+                "audience": "sdx-cli",
                 "authorize_url": "https://authz-apps-gov-bc-ca.dev.api.gov.bc.ca/auth/realms/aps/protocol/openid-connect/auth",
-                "client_id": "sdx-bruno-client",
+                "client_id": "sdx-cli",
                 "scopes": "openid",
                 "token_url": "https://authz-apps-gov-bc-ca.dev.api.gov.bc.ca/auth/realms/aps/protocol/openid-connect/token"
               }
@@ -100,6 +100,10 @@ restish api edit
       }
     }
     ```
+
+    The `sdx-bruno-client` OAuth client is not registered in the DEV `aps`
+    realm and returns `Client not found`. Use `sdx-cli` for both `client_id`
+    and `audience` in DEV.
 
 ### Interacting with the API
 


### PR DESCRIPTION
## Summary

Fixes the documentation-text errata related to `aps-infra-platform` from `DOCUMENTATION-ERRATA-OUTSTANDING.md` (20 of 32 tracked items — the rest live in other repos or are implementation-only defects, see below), plus two items discovered in a second round of reference-implementation work (`DOCUMENTATION-ERRATA-OUTSTANDING-r1.md`).

## Errata resolved (round 1 — `DOCUMENTATION-ERRATA-OUTSTANDING.md`)

- **ERR-001** — DEV Restish profile `client_id`/`audience` corrected to `sdx-cli` (`reference/restish-cli.md`)
- **ERR-002** — Org onboarding role corrected to `system-admin`; documented the org-level vs system-level role distinction (`how-to/sdx-org-onboarding.md`)
- **ERR-003** — Fixed conflicting `tags` JSON shape to `array<string>` (`how-to/sdx-org-onboarding.md`)
- **ERR-004** — Fixed broken links to the Connection Gateway Patterns page (`how-to/sdx-connections.md`, `how-to/sdx-org-signing.md`)
- **ERR-005** — Corrected misleading onboarding help-text descriptions (`how-to/sdx-org-onboarding.md`)
- **ERR-008** — Defined PZGW as the special public consumer host (`concepts/secure-data-exchange.md`)
- **ERR-009** — Added a warning about retrying legacy runtime gateway registration (`how-to/sdx-edge-servers.md`)
- **ERR-010** — Corrected the documented effective authorization scope (`GatewayPattern.Publish` / `GatewayConfig.Publish`) (`how-to/sdx-edge-servers.md`)
- **ERR-011** — Documented the CLI/bootstrap path for SDX namespace access (`how-to/sdx-edge-servers.md`)
- **ERR-012** — Clarified `diff` response semantics when no changes are made (`how-to/sdx-edge-servers.md`)
- **ERR-013** — Added a warning to check runtime hosting before subsystem gateway registration (`how-to/sdx-subsystems.md`)
- **ERR-014** — Documented that subsystem gateway registration is create-only, with no partial-state recovery (`how-to/sdx-subsystems.md`)
- **ERR-015** — Added validator troubleshooting guidance for engine failures reported as unavailability (`how-to/sdx-services.md`)
- **ERR-019** — Documented the public catalog OAD retrieval endpoints/limits (`how-to/sdx-services.md`)
- **ERR-020** — Documented the runtime-required policy version for connection creation (`how-to/sdx-connections.md`)
- **ERR-021** — Clarified `sdx-p2p-*` are connection resources, not directly invoked patterns (`how-to/sdx-connection-patterns.md`)
- **ERR-023** — Added the `requesterDetails` record required at R0 activation to the example (`how-to/sdx-connections.md`)
- **ERR-026** — Added a note on the edge CA / Kong upstream peer TLS trust list (`how-to/sdx-edge-servers.md`)
- **ERR-029** — Documented the OAS security-scope enforcement gap in SDX patterns (`how-to/sdx-services.md`)
- **ERR-030** — Documented the integration access-request path missing from connection docs (`how-to/sdx-connections.md`)
- **ERR-033** — Fixed `certificatePem` array shape in runtime signing-key instructions (`how-to/sdx-edge-servers.md`)

## Errata resolved (round 2 — `DOCUMENTATION-ERRATA-OUTSTANDING-r1.md`)

- **ERR-034** — Fixed the `generate-one-time-use-token` Reference path, which omitted the required `/environments/{environment}` segment (`how-to/sdx-edge-servers.md`)
- **ENH-001** — Documented the new `includeAccess` query parameter on `organization-list` (`/catalog/organizations`), which returns each organization's RBAC role membership; calls out that it does not require authentication, matching the rest of the (already-public) listing (`how-to/sdx-org-onboarding.md`)
- **ENH-002** — Documented the new `get-subsystem-access`/`put-subsystem-access` operations for administering a subsystem's `system-owner`/`tech-lead`/`access-manager` RBAC membership after registration, including the full-sync (revokes anything omitted) behavior and supported role list (`how-to/sdx-subsystems.md`); also restored broken indentation on two adjacent warning admonitions that had lost their required 4-space indent

Also fixed, ungrouped: the `provision-config-from-pattern` example under "Provision default routes and controls" used pattern ID `sdx-runtime-group.v1`; the server only recognizes `sdx-runtime-group.r1` (`how-to/sdx-edge-servers.md`).

## Out of scope (not addressed here)

- **ERR-006, ERR-007** — affected docs live in `bcgov-c/api-serv-infra`, not this repo
- **ERR-016, ERR-017** — affected docs/Dockerfile live in `bcgov/gwa-api`
- **ERR-018, ERR-024, ERR-025, ERR-027, ERR-028, ERR-031, ERR-032** — implementation-only defects (code, Helm chart, pipeline); no `aps-infra-platform` documentation is listed as affected

## Files changed

- `documentation/concepts/secure-data-exchange.md`
- `documentation/how-to/sdx-connection-patterns.md`
- `documentation/how-to/sdx-connections.md`
- `documentation/how-to/sdx-edge-servers.md`
- `documentation/how-to/sdx-org-onboarding.md`
- `documentation/how-to/sdx-org-signing.md`
- `documentation/how-to/sdx-services.md`
- `documentation/how-to/sdx-subsystems.md`
- `documentation/reference/restish-cli.md`

